### PR TITLE
feat: Implement validate_input helper function for consistent input validation

### DIFF
--- a/agentipy/helpers/__init__.py
+++ b/agentipy/helpers/__init__.py
@@ -9,3 +9,47 @@ def fix_asyncio_for_windows():
     """
     if platform.system() in ["Windows", "win32"]:
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+def validate_input (data:dict,schema:dict) -> None:
+    """
+    Validates the input against the schema.
+
+    Schema format:{
+    "field_name":{
+        "type":type,
+        "required":bool,
+        "min_length":int,
+        "min":int,
+        "max":int,
+        "choices":list ,# optional for enums
+        }
+    }
+    """
+    for field, rules in schema.items():
+        # this will check for the required fields
+        if rules.get("required", True) and field not in data:
+            raise ValueError(f"Missing required field: {field}")
+            
+        if field in data:
+            value = data[field]
+            
+            # Type checking
+            if not isinstance(value, rules["type"]):
+                raise ValueError(f"{field} must be of type {rules['type'].__name__}")
+            
+            # Length validation for strings/lists
+            if rules.get("min_length") is not None and len(value) < rules["min_length"]:
+                raise ValueError(f"{field} must have minimum length of {rules['min_length']}")
+            
+            # Range validation for numbers
+            if isinstance(value, (int, float)):
+                if rules.get("min") is not None and value < rules["min"]:
+                    raise ValueError(f"{field} must be greater than {rules['min']}")
+                if rules.get("max") is not None and value > rules["max"]:
+                    raise ValueError(f"{field} must be less than {rules['max']}")
+            
+            # Choices validation
+            if rules.get("choices") and value not in rules["choices"]:
+                raise ValueError(f"{field} must be one of {rules['choices']}")
+    

--- a/agentipy/langchain/__init__.py
+++ b/agentipy/langchain/__init__.py
@@ -597,6 +597,11 @@ class SolanaMeteoraDLMMTool(BaseTool):
     
             if not isinstance(data["fee_bps"], int) or not (0 <= data["fee_bps"] <= 10000):
                 raise ValueError("fee_bps must be an integer between 0 and 10000")
+            if not isinstance(data["activation_type"], str):
+                raise ValueError("activation_type must be a string")
+            if not isinstance(data["has_alpha_vault"], bool):
+                raise ValueError("has_alpha_vault must be a boolean")
+            
 
             activation_type_mapping = {
                 "Slot": ActivationType.Slot,
@@ -4671,7 +4676,25 @@ class OpenPerpTradeShortTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["price", "collateral_amount"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+            if not isinstance(data["collateral_amount"], float):
+                raise ValueError("collateral_amount must be a float")
+            if "collateral_mint" in data and not isinstance(data["collateral_mint"], str):
+                raise ValueError("collateral_mint must be a string")
+            if "leverage" in data and not isinstance(data["leverage"], float):
+                raise ValueError("leverage must be a float")
+            if "trade_mint" in data and not isinstance(data["trade_mint"], str):
+                raise ValueError("trade_mint must be a string")
+            if "slippage" in data and not isinstance(data["slippage"], float):
+                raise ValueError("slippage must be a float")
+            
             transaction = await self.solana_kit.open_perp_trade_short(
                 price=data["price"],
                 collateral_amount=data["collateral_amount"],
@@ -4690,8 +4713,8 @@ class OpenPerpTradeShortTool(BaseTool):
                 "message": f"Error opening perp short trade: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
     
 class Create3LandCollectionTool(BaseTool):
     name: str = "create_3land_collection"
@@ -4717,7 +4740,25 @@ class Create3LandCollectionTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["collection_symbol", "collection_name", "collection_description"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["collection_symbol"], str):
+                raise ValueError("collection_symbol must be a string")
+            if not isinstance(data["collection_name"], str):
+                raise ValueError("collection_name must be a string")
+            if not isinstance(data["collection_description"], str):
+                raise ValueError("collection_description must be a string")
+            if "main_image_url" in data and not isinstance(data["main_image_url"], str):
+                raise ValueError("main_image_url must be a string")
+            if "cover_image_url" in data and not isinstance(data["cover_image_url"], str):
+                raise ValueError("cover_image_url must be a string")
+            if "is_devnet" in data and not isinstance(data["is_devnet"], bool):
+                raise ValueError("is_devnet must be a boolean")
+            
             transaction = await self.solana_kit.create_3land_collection(
                 collection_symbol=data["collection_symbol"],
                 collection_name=data["collection_name"],
@@ -4736,8 +4777,8 @@ class Create3LandCollectionTool(BaseTool):
                 "message": f"Error creating 3land collection: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class Create3LandNFTTool(BaseTool):
     name: str = "create_3land_nft"
@@ -4770,7 +4811,39 @@ class Create3LandNFTTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["item_name", "seller_fee", "item_amount", "item_symbol", "item_description", "traits"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["item_name"], str):
+                raise ValueError("item_name must be a string")
+            if not isinstance(data["seller_fee"], float):
+                raise ValueError("seller_fee must be a float")
+            if not isinstance(data["item_amount"], int):
+                raise ValueError("item_amount must be an integer")
+            if not isinstance(data["item_symbol"], str):
+                raise ValueError("item_symbol must be a string")
+            if not isinstance(data["item_description"], str):
+                raise ValueError("item_description must be a string")
+            if not isinstance(data["traits"], dict):
+                raise ValueError("traits must be a dictionary")
+            if "price" in data and not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+            if "main_image_url" in data and not isinstance(data["main_image_url"], str):
+                raise ValueError("main_image_url must be a string")
+            if "cover_image_url" in data and not isinstance(data["cover_image_url"], str):
+                raise ValueError("cover_image_url must be a string")
+            if "spl_hash" in data and not isinstance(data["spl_hash"], str):
+                raise ValueError("spl_hash must be a string")
+            if "pool_name" in data and not isinstance(data["pool_name"], str):
+                raise ValueError("pool_name must be a string")
+            if "is_devnet" in data and not isinstance(data["is_devnet"], bool):
+                raise ValueError("is_devnet must be a boolean")
+            if "with_pool" in data and not isinstance(data["with_pool"], bool):
+                raise ValueError("with_pool must be a boolean")
+            
             transaction = await self.solana_kit.create_3land_nft(
                 item_name=data["item_name"],
                 seller_fee=data["seller_fee"],
@@ -4796,7 +4869,7 @@ class Create3LandNFTTool(BaseTool):
                 "message": f"Error creating 3land NFT: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun.")
 
 class CreateDriftUserAccountTool(BaseTool):
@@ -4819,7 +4892,17 @@ class CreateDriftUserAccountTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["deposit_amount", "deposit_symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["deposit_amount"], float):
+                raise ValueError("deposit_amount must be a float")
+            if not isinstance(data["deposit_symbol"], str):
+                raise ValueError("deposit_symbol must be a string")
+            
             transaction = await self.solana_kit.create_drift_user_account(
                 deposit_amount=data["deposit_amount"],
                 deposit_symbol=data["deposit_symbol"],
@@ -4834,8 +4917,8 @@ class CreateDriftUserAccountTool(BaseTool):
                 "message": f"Error creating Drift user account: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class DepositToDriftUserAccountTool(BaseTool):
     name: str = "deposit_to_drift_user_account"
@@ -4858,7 +4941,19 @@ class DepositToDriftUserAccountTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if "is_repayment" in data and not isinstance(data["is_repayment"], bool):
+                raise ValueError("is_repayment must be a boolean")
+            
             transaction = await self.solana_kit.deposit_to_drift_user_account(
                 amount=data["amount"],
                 symbol=data["symbol"],
@@ -4874,8 +4969,8 @@ class DepositToDriftUserAccountTool(BaseTool):
                 "message": f"Error depositing to Drift user account: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
     
 class WithdrawFromDriftUserAccountTool(BaseTool):
     name: str = "withdraw_from_drift_user_account"
@@ -4898,7 +4993,19 @@ class WithdrawFromDriftUserAccountTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if "is_borrow" in data and not isinstance(data["is_borrow"], bool):
+                raise ValueError("is_borrow must be a boolean")
+
             transaction = await self.solana_kit.withdraw_from_drift_user_account(
                 amount=data["amount"],
                 symbol=data["symbol"],
@@ -4914,8 +5021,8 @@ class WithdrawFromDriftUserAccountTool(BaseTool):
                 "message": f"Error withdrawing from Drift user account: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class TradeUsingDriftPerpAccountTool(BaseTool):
     name: str = "trade_using_drift_perp_account"
@@ -4940,7 +5047,23 @@ class TradeUsingDriftPerpAccountTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "symbol", "action", "trade_type"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if not isinstance(data["action"], str):
+                raise ValueError("action must be a string")
+            if not isinstance(data["trade_type"], str):
+                raise ValueError("trade_type must be a string")
+            if "price" in data and not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+
             transaction = await self.solana_kit.trade_using_drift_perp_account(
                 amount=data["amount"],
                 symbol=data["symbol"],
@@ -4958,8 +5081,8 @@ class TradeUsingDriftPerpAccountTool(BaseTool):
                 "message": f"Error trading using Drift perp account: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class CheckIfDriftAccountExistsTool(BaseTool):
     name: str = "check_if_drift_account_exists"
@@ -4975,7 +5098,7 @@ class CheckIfDriftAccountExistsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             exists = await self.solana_kit.check_if_drift_account_exists()
             return {
@@ -4988,7 +5111,7 @@ class CheckIfDriftAccountExistsTool(BaseTool):
                 "message": f"Error checking Drift account existence: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun.")
 
 class DriftUserAccountInfoTool(BaseTool):
@@ -5005,7 +5128,7 @@ class DriftUserAccountInfoTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             account_info = await self.solana_kit.drift_user_account_info()
             return {
@@ -5018,7 +5141,7 @@ class DriftUserAccountInfoTool(BaseTool):
                 "message": f"Error fetching Drift user account info: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun.")
 
 class GetAvailableDriftMarketsTool(BaseTool):
@@ -5035,7 +5158,7 @@ class GetAvailableDriftMarketsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             markets = await self.solana_kit.get_available_drift_markets()
             return {
@@ -5048,7 +5171,7 @@ class GetAvailableDriftMarketsTool(BaseTool):
                 "message": f"Error fetching available Drift markets: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun.")
 
 class StakeToDriftInsuranceFundTool(BaseTool):
@@ -5071,7 +5194,17 @@ class StakeToDriftInsuranceFundTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             transaction = await self.solana_kit.stake_to_drift_insurance_fund(
                 amount=data["amount"],
                 symbol=data["symbol"]
@@ -5086,8 +5219,8 @@ class StakeToDriftInsuranceFundTool(BaseTool):
                 "message": f"Error staking to Drift insurance fund: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class RequestUnstakeFromDriftInsuranceFundTool(BaseTool):
     name: str = "request_unstake_from_drift_insurance_fund"
@@ -5109,7 +5242,17 @@ class RequestUnstakeFromDriftInsuranceFundTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             transaction = await self.solana_kit.request_unstake_from_drift_insurance_fund(
                 amount=data["amount"],
                 symbol=data["symbol"]
@@ -5124,8 +5267,8 @@ class RequestUnstakeFromDriftInsuranceFundTool(BaseTool):
                 "message": f"Error requesting unstake from Drift insurance fund: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class UnstakeFromDriftInsuranceFundTool(BaseTool):
     name: str = "unstake_from_drift_insurance_fund"
@@ -5146,7 +5289,15 @@ class UnstakeFromDriftInsuranceFundTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             transaction = await self.solana_kit.unstake_from_drift_insurance_fund(
                 symbol=data["symbol"]
             )
@@ -5160,8 +5311,8 @@ class UnstakeFromDriftInsuranceFundTool(BaseTool):
                 "message": f"Error unstaking from Drift insurance fund: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class DriftSwapSpotTokenTool(BaseTool):
     name: str = "drift_swap_spot_token"
@@ -5186,7 +5337,15 @@ class DriftSwapSpotTokenTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["from_symbol", "to_symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["from_symbol"], str):
+                raise ValueError("from_symbol must be a string")
+        
             transaction = await self.solana_kit.drift_swap_spot_token(
                 from_symbol=data["from_symbol"],
                 to_symbol=data["to_symbol"],
@@ -5204,8 +5363,8 @@ class DriftSwapSpotTokenTool(BaseTool):
                 "message": f"Error swapping spot token on Drift: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class GetDriftPerpMarketFundingRateTool(BaseTool):
     name: str = "get_drift_perp_market_funding_rate"
@@ -5227,7 +5386,15 @@ class GetDriftPerpMarketFundingRateTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+        
             funding_rate = await self.solana_kit.get_drift_perp_market_funding_rate(
                 symbol=data["symbol"],
                 period=data.get("period", "year"),
@@ -5242,8 +5409,8 @@ class GetDriftPerpMarketFundingRateTool(BaseTool):
                 "message": f"Error getting Drift perp market funding rate: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class GetDriftEntryQuoteOfPerpTradeTool(BaseTool):
     name: str = "get_drift_entry_quote_of_perp_trade"
@@ -5266,7 +5433,19 @@ class GetDriftEntryQuoteOfPerpTradeTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "symbol", "action"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if not isinstance(data["action"], str):
+                raise ValueError("action must be a string")
+            
             entry_quote = await self.solana_kit.get_drift_entry_quote_of_perp_trade(
                 amount=data["amount"],
                 symbol=data["symbol"],
@@ -5282,8 +5461,8 @@ class GetDriftEntryQuoteOfPerpTradeTool(BaseTool):
                 "message": f"Error getting Drift entry quote of perp trade: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class GetDriftLendBorrowApyTool(BaseTool):
     name: str = "get_drift_lend_borrow_apy"
@@ -5304,7 +5483,15 @@ class GetDriftLendBorrowApyTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             apy_data = await self.solana_kit.get_drift_lend_borrow_apy(
                 symbol=data["symbol"]
             )
@@ -5318,8 +5505,8 @@ class GetDriftLendBorrowApyTool(BaseTool):
                 "message": f"Error getting Drift lend/borrow APY: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class CreateDriftVaultTool(BaseTool):
     name: str = "create_drift_vault"
@@ -5348,7 +5535,32 @@ class CreateDriftVaultTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["name", "market_name", "redeem_period", "max_tokens", "min_deposit_amount", "management_fee", "profit_share"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["name"], str):
+                raise ValueError("name must be a string")
+            if not isinstance(data["market_name"], str):
+                raise ValueError("market_name must be a string")
+            if not isinstance(data["redeem_period"], int):
+                raise ValueError("redeem_period must be an integer")
+            if not isinstance(data["max_tokens"], int):
+                raise ValueError("max_tokens must be an integer")
+            if not isinstance(data["min_deposit_amount"], float):
+                raise ValueError("min_deposit_amount must be a float")
+            if not isinstance(data["management_fee"], float):
+                raise ValueError("management_fee must be a float")
+            if not isinstance(data["profit_share"], float):
+                raise ValueError("profit_share must be a float")
+            if not isinstance(data["hurdle_rate"], float):
+                raise ValueError("hurdle_rate must be a float")
+            if not isinstance(data["permissioned"], bool):
+                raise ValueError("permissioned must be a boolean")
+            
+            
             vault_details = await self.solana_kit.create_drift_vault(
                 name=data["name"],
                 market_name=data["market_name"],
@@ -5370,8 +5582,8 @@ class CreateDriftVaultTool(BaseTool):
                 "message": f"Error creating Drift vault: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class UpdateDriftVaultDelegateTool(BaseTool):
     name: str = "update_drift_vault_delegate"
@@ -5393,7 +5605,17 @@ class UpdateDriftVaultDelegateTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["vault", "delegate_address"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["vault"], str):
+                raise ValueError("vault must be a string")
+            if not isinstance(data["delegate_address"], str):
+                raise ValueError("delegate_address must be a string")
+            
             transaction = await self.solana_kit.update_drift_vault_delegate(
                 vault=data["vault"],
                 delegate_address=data["delegate_address"],
@@ -5408,8 +5630,8 @@ class UpdateDriftVaultDelegateTool(BaseTool):
                 "message": f"Error updating Drift vault delegate: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class UpdateDriftVaultTool(BaseTool):
     name: str = "update_drift_vault"
@@ -5439,7 +5661,33 @@ class UpdateDriftVaultTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["vault_address", "name", "market_name", "redeem_period", "max_tokens", "min_deposit_amount", "management_fee", "profit_share"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["vault_address"], str):
+                raise ValueError("vault_address must be a string")
+            if not isinstance(data["name"], str):
+                raise ValueError("name must be a string")
+            if not isinstance(data["market_name"], str):
+                raise ValueError("market_name must be a string")
+            if not isinstance(data["redeem_period"], int):
+                raise ValueError("redeem_period must be an integer")
+            if not isinstance(data["max_tokens"], int):
+                raise ValueError("max_tokens must be an integer")
+            if not isinstance(data["min_deposit_amount"], float):
+                raise ValueError("min_deposit_amount must be a float")
+            if not isinstance(data["management_fee"], float):
+                raise ValueError("management_fee must be a float")
+            if not isinstance(data["profit_share"], float):
+                raise ValueError("profit_share must be a float")
+            if "hurdle_rate" in data and not isinstance(data["hurdle_rate"], float):
+                raise ValueError("hurdle_rate must be a float")
+            if "permissioned" in data and not isinstance(data["permissioned"], bool):
+                raise ValueError("permissioned must be a boolean")
+            
             vault_update = await self.solana_kit.update_drift_vault(
                 vault_address=data["vault_address"],
                 name=data["name"],
@@ -5484,7 +5732,15 @@ class GetDriftVaultInfoTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["vault_name"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["vault_name"], str):
+                raise ValueError("vault_name must be a string")
+            
             vault_info = await self.solana_kit.get_drift_vault_info(
                 vault_name=data["vault_name"]
             )
@@ -5498,8 +5754,8 @@ class GetDriftVaultInfoTool(BaseTool):
                 "message": f"Error retrieving Drift vault info: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
     
 class DepositIntoDriftVaultTool(BaseTool):
     name: str = "deposit_into_drift_vault"
@@ -5521,7 +5777,17 @@ class DepositIntoDriftVaultTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["amount", "vault"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["vault"], str):
+                raise ValueError("vault must be a string")
+            
             transaction = await self.solana_kit.deposit_into_drift_vault(
                 amount=data["amount"],
                 vault=data["vault"]
@@ -5536,8 +5802,8 @@ class DepositIntoDriftVaultTool(BaseTool):
                 "message": f"Error depositing into Drift vault: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class RequestWithdrawalFromDriftVaultTool(BaseTool):
     name: str = "request_withdrawal_from_drift_vault"
@@ -5558,8 +5824,18 @@ class RequestWithdrawalFromDriftVaultTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
-        try:
-            data = json.loads(input)
+        try:    
+            required_fields = ["amount", "vault"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["vault"], str):
+                raise ValueError("vault must be a string")
+            
             transaction = await self.solana_kit.request_withdrawal_from_drift_vault(
                 amount=data["amount"],
                 vault=data["vault"]
@@ -5574,8 +5850,8 @@ class RequestWithdrawalFromDriftVaultTool(BaseTool):
                 "message": f"Error requesting withdrawal from Drift vault: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class WithdrawFromDriftVaultTool(BaseTool):
     name: str = "withdraw_from_drift_vault"
@@ -5596,7 +5872,15 @@ class WithdrawFromDriftVaultTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["vault"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["vault"], str):
+                raise ValueError("vault must be a string")
+            
             transaction = await self.solana_kit.withdraw_from_drift_vault(
                 vault=data["vault"]
             )
@@ -5610,8 +5894,8 @@ class WithdrawFromDriftVaultTool(BaseTool):
                 "message": f"Error withdrawing from Drift vault: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class DeriveDriftVaultAddressTool(BaseTool):
     name: str = "derive_drift_vault_address"
@@ -5632,7 +5916,15 @@ class DeriveDriftVaultAddressTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["name"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["name"], str):
+                raise ValueError("name must be a string")
+            
             vault_address = await self.solana_kit.derive_drift_vault_address(
                 name=data["name"]
             )
@@ -5646,8 +5938,8 @@ class DeriveDriftVaultAddressTool(BaseTool):
                 "message": f"Error deriving Drift vault address: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class TradeUsingDelegatedDriftVaultTool(BaseTool):
     name: str = "trade_using_delegated_drift_vault"
@@ -5673,7 +5965,25 @@ class TradeUsingDelegatedDriftVaultTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["vault", "amount", "symbol", "action", "trade_type"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["vault"], str):
+                raise ValueError("vault must be a string")
+            if not isinstance(data["amount"], float):
+                raise ValueError("amount must be a float")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if not isinstance(data["action"], str):
+                raise ValueError("action must be a string")
+            if not isinstance(data["trade_type"], str):
+                raise ValueError("trade_type must be a string")
+            if "price" in data and not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+            
             transaction = await self.solana_kit.trade_using_delegated_drift_vault(
                 vault=data["vault"],
                 amount=data["amount"],
@@ -5692,8 +6002,8 @@ class TradeUsingDelegatedDriftVaultTool(BaseTool):
                 "message": f"Error trading using delegated Drift vault: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
     
 class FlashOpenTradeTool(BaseTool):
     name: str = "flash_open_trade"
@@ -5717,7 +6027,21 @@ class FlashOpenTradeTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["token", "side", "collateralUsd", "leverage"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["token"], str):
+                raise ValueError("token must be a string")
+            if not isinstance(data["side"], str):
+                raise ValueError("side must be a string")
+            if not isinstance(data["collateralUsd"], float):
+                raise ValueError("collateralUsd must be a float")
+            if not isinstance(data["leverage"], float):
+                raise ValueError("leverage must be a float")
+
             transaction = await self.solana_kit.flash_open_trade(
                 token=data["token"],
                 side=data["side"],
@@ -5734,7 +6058,7 @@ class FlashOpenTradeTool(BaseTool):
                 "message": f"Error opening flash trade: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun.")
 
 class FlashCloseTradeTool(BaseTool):
@@ -5757,7 +6081,17 @@ class FlashCloseTradeTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["token", "side"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["token"], str):
+                raise ValueError("token must be a string")
+            if not isinstance(data["side"], str):
+                raise ValueError("side must be a string")
+            
             transaction = await self.solana_kit.flash_close_trade(
                 token=data["token"],
                 side=data["side"]
@@ -5772,8 +6106,8 @@ class FlashCloseTradeTool(BaseTool):
                 "message": f"Error closing flash trade: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class ResolveAllDomainsTool(BaseTool):
     name: str = "resolve_all_domains"
@@ -5794,13 +6128,21 @@ class ResolveAllDomainsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["domain"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["domain"], str):
+                raise ValueError("domain must be a string")
+            
             domain_tld = await self.solana_kit.resolve_all_domains(data["domain"])
             return {"tld": domain_tld, "message": "Success"} if domain_tld else {"message": "Domain resolution failed"}
         except Exception as e:
             return {"message": f"Error resolving domain: {str(e)}"}
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class GetOwnedDomainsForTLDTool(BaseTool):
@@ -5822,7 +6164,15 @@ class GetOwnedDomainsForTLDTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["tld"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["tld"], str):
+                raise ValueError("tld must be a string")
+            
             owned_domains = await self.solana_kit.get_owned_domains_for_tld(data["tld"])
             return {"domains": owned_domains, "message": "Success"} if owned_domains else {"message": "No owned domains found"}
         except Exception as e:
@@ -5845,14 +6195,14 @@ class GetAllDomainsTLDsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             tlds = await self.solana_kit.get_all_domains_tlds()
             return {"tlds": tlds, "message": "Success"} if tlds else {"message": "No TLDs found"}
         except Exception as e:
             return {"message": f"Error fetching TLDs: {str(e)}"}
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class GetOwnedAllDomainsTool(BaseTool):
@@ -5874,13 +6224,21 @@ class GetOwnedAllDomainsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["owner"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["owner"], str):
+                raise ValueError("owner must be a string")
+            
             owned_domains = await self.solana_kit.get_owned_all_domains(data["owner"])
             return {"domains": owned_domains, "message": "Success"} if owned_domains else {"message": "No owned domains found"}
         except Exception as e:
             return {"message": f"Error fetching owned domains: {str(e)}"}
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
     
 def create_solana_tools(solana_kit: SolanaAgentKit):

--- a/agentipy/langchain/__init__.py
+++ b/agentipy/langchain/__init__.py
@@ -58,7 +58,20 @@ class SolanaTransferTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["to", "amount"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if "to" in data and not isinstance(data["to"], str):
+                raise ValueError("To must be a string")
+            if not isinstance(data["amount"], int) or data["amount"] <= 0:
+                raise ValueError("Amount must be a positive integer")
+            if "mint" in data and not isinstance(data["mint"], str):
+                raise ValueError("Mint must be a string")
+            
+
             recipient = Pubkey.from_string(data["to"])
             mint_address = Pubkey.from_string(data["mint"]) if "mint" in data else None
 
@@ -96,12 +109,22 @@ class SolanaDeployTokenTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
+
         try:
+            required_fields = ["decimals", "initialSupply"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["decimals"], int) or data["decimals"] < 0 or data["decimals"] > 9:
+                raise ValueError("Decimals must be an integer between 0 and 9")
+            if not isinstance(data["initialSupply"], int) or data["initialSupply"] < 0:
+                raise ValueError("Initial supply must be a positive integer")
+
             decimals = data.get("decimals", 9)
 
-            if decimals < 0 or decimals > 9:
-                raise ValueError("Decimals must be between 0 and 9")
+           
 
             token_details = await self.solana_kit.deploy_token(decimals)
             return {
@@ -141,7 +164,21 @@ class SolanaTradeTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["output_mint", "input_amount"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["input_amount"], int) or data["input_amount"] <= 0:
+                raise ValueError("Input amount must be a positive integer")
+            if "input_mint" in data and not isinstance(data["input_mint"], str):
+                raise ValueError("Input mint must be a string")
+            if "slippage_bps" in data and not isinstance(data["slippage_bps"], int):
+                raise ValueError("Slippage bps must be an integer")
+            if "output_mint" in data and not isinstance(data["output_mint"], str):
+                raise ValueError("Output mint must be a string")
+
             output_mint = Pubkey.from_string(data["output_mint"])
             input_mint = Pubkey.from_string(data["input_mint"]) if "input_mint" in data else None
             slippage_bps = data.get("slippage_bps", 100)
@@ -263,7 +300,18 @@ class SolanaCreateImageTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["prompt"]
             data = json.loads(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["prompt"], str):
+                raise ValueError("Prompt must be a string")
+            if "size" in data and not isinstance(data["size"], str):
+                raise ValueError("Size must be a string")
+            if "n" in data and not isinstance(data["n"], int):
+                raise ValueError("N must be an integer")
+
             prompt = data["prompt"]
             size = data.get("size", "1024x1024")
             n = data.get("n", 1)
@@ -334,7 +382,21 @@ class SolanaPumpFunTokenTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["token_name", "token_ticker", "description", "image_url"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["token_name"], str):
+                raise ValueError("Token name must be a string")
+            if not isinstance(data["token_ticker"], str):
+                raise ValueError("Token ticker must be a string")
+            if not isinstance(data["description"], str):
+                raise ValueError("Description must be a string")
+            if not isinstance(data["image_url"], str):
+                raise ValueError("Image URL must be a string")
+            
             result = await self.solana_kit.launch_pump_fun_token(
                 data["token_name"],
                 data["token_ticker"],
@@ -373,8 +435,17 @@ class SolanaFetchPriceTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def call(self, input: str) -> str:
-        try:
-            token_id = input.strip()
+        try:    
+            required_fields = ["token_id"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["token_id"], str):
+                raise ValueError("Token ID must be a string")
+
+            token_id = data["token_id"]
             price = await self.solana_kit.fetch_price(token_id)
             return json.dumps({
                 "status": "success",
@@ -408,7 +479,16 @@ class SolanaTokenDataTool(BaseTool):
 
     async def call(self, input: str) -> str:
         try:
-            mint_address = input.strip()
+            required_fields = ["mint_address"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["mint_address"], str):
+                raise ValueError("Mint address must be a string")
+
+            mint_address = data["mint_address"]
             token_data = await self.solana_kit.get_token_data_by_address(mint_address)
             return json.dumps({
                 "status": "success",
@@ -441,7 +521,16 @@ class SolanaTokenDataByTickerTool(BaseTool):
 
     async def call(self, input: str) -> str:
         try:
-            ticker = input.strip()
+            required_fields = ["ticker"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["ticker"], str):
+                raise ValueError("Ticker must be a string")
+
+            ticker = data["ticker"]
             token_data = await self.solana_kit.get_token_data_by_ticker(ticker)
             return json.dumps({
                 "status": "success",
@@ -566,7 +655,19 @@ class SolanaRaydiumBuyTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["pair_address", "sol_in", "slippage"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["pair_address"], str):
+                raise ValueError("Pair address must be a string")
+            if not isinstance(data["sol_in"], float) or data["sol_in"] <= 0:
+                raise ValueError("SOL in must be a positive float")
+            if not isinstance(data["slippage"], int) or not (0 <= data["slippage"] <= 100):
+                raise ValueError("Slippage must be an integer between 0 and 100")
+            
             pair_address = data["pair_address"]
             sol_in = data.get("sol_in", 0.01)  # Default to 0.01 SOL if not provided
             slippage = data.get("slippage", 5)  # Default to 5% slippage if not provided
@@ -610,7 +711,21 @@ class SolanaRaydiumSellTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_keys = [   
+                "pair_address",
+                "percentage",
+                "slippage"
+            ]
             data = toJSON(input)
+            
+            for key in required_keys:
+                if key not in data:
+                    raise ValueError(f"Missing required key: {key}")
+            if not isinstance(data["percentage"], int) or not (0 <= data["percentage"] <= 100):
+                raise ValueError("percentage must be an integer between 0 and 100")
+            if not isinstance(data["slippage"], int) or not (0 <= data["slippage"] <= 100):
+                raise ValueError("slippage must be an integer between 0 and 100")
+            
             pair_address = data["pair_address"]
             percentage = data.get("percentage", 100)  # Default to 100% if not provided
             slippage = data.get("slippage", 5)  # Default to 5% slippage if not provided
@@ -652,11 +767,17 @@ class SolanaBurnAndCloseTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["token_account"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["token_account"], str):
+                raise ValueError("Token account must be a string")
+            
             token_account = data["token_account"]
 
-            if not token_account:
-                raise ValueError("Token account is required.")
 
             result = await self.solana_kit.burn_and_close_accounts(token_account)
 
@@ -692,7 +813,12 @@ class SolanaBurnAndCloseMultipleTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["token_accounts"]
             data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
             token_accounts = data.get("token_accounts", [])
 
             if not isinstance(token_accounts, list) or not token_accounts:
@@ -805,24 +931,19 @@ class SolanaBuyUsingMoonshotTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            required_keys = [
-                "mint_str",
-                "collateral_amount",
-                "slippage_bps"
-            ]
+            required_fields = ["mint_str", "collateral_amount", "slippage_bps"]
             data = toJSON(input)
-            
-            for key in required_keys:
-                if key not in data:
-                    raise ValueError(f"Missing required key: {key}")
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
             if not isinstance(data["collateral_amount"], float) or data["collateral_amount"] <= 0:
                 raise ValueError("collateral_amount must be a positive float")
-            if not isinstance(data["slippage_bps"], int) or data["slippage_bps"] < 0:
-                raise ValueError("slippage_bps must be a non-negative integer")
-            
+            if not isinstance(data["slippage_bps"], int) or not (0 <= data["slippage_bps"] <= 10000):
+                raise ValueError("slippage_bps must be an integer between 0 and 10000")
             mint_str = data["mint_str"]
             collateral_amount = data.get("collateral_amount", 0.01)
             slippage_bps = data.get("slippage_bps", 500)
+            
             result = await self.solana_kit.buy_using_moonshot(mint_str, collateral_amount, slippage_bps)
 
             return {
@@ -859,7 +980,15 @@ class SolanaSellUsingMoonshotTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
+            required_fields = ["mint_str", "token_balance", "slippage_bps"]
             data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["token_balance"], float) or data["token_balance"] <= 0:
+                raise ValueError("token_balance must be a positive float")
+            if not isinstance(data["slippage_bps"], int) or not (0 <= data["slippage_bps"] <= 10000):
+                raise ValueError("slippage_bps must be an integer between 0 and 10000")
             mint_str = data["mint_str"]
             token_balance = data.get("token_balance", 0.01)
             slippage_bps = data.get("slippage_bps", 500)
@@ -906,7 +1035,11 @@ class SolanaPythGetPriceTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["mint_address"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
             mint_address = data["mint_address"]
 
             result = await self.solana_kit.pythFetchPrice(mint_address)
@@ -946,7 +1079,11 @@ class SolanaHeliusGetBalancesTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["address"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
             address = data["address"]
 
             result = await self.solana_kit.get_balances(address)
@@ -984,7 +1121,13 @@ class SolanaHeliusGetAddressNameTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["address"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["address"], str) or len(data["address"]) == 0:
+                raise ValueError("address must be a non-empty string")
             address = data["address"]
 
             result = await self.solana_kit.get_address_name(address)
@@ -1033,7 +1176,15 @@ class SolanaHeliusGetNftEventsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["accounts"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            
+           
+            
+
             accounts = data["accounts"]
             types = data.get("types")
             sources = data.get("sources")
@@ -1086,8 +1237,14 @@ class SolanaHeliusGetMintlistsTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
+
         try:
-            data = json.loads(input)
+            required_fields = ["first_verified_creators", ]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            
             first_verified_creators = data["first_verified_creators"]
             verified_collection_addresses = data.get("verified_collection_addresses")
             limit = data.get("limit")
@@ -1125,8 +1282,12 @@ class SolanaHeliusGetNFTFingerprintTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
-        try:
-            data = json.loads(input)
+        try:    
+            required_fields = ["mints"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
             mints = data["mints"]
 
             result = await self.solana_kit.get_nft_fingerprint(mints)
@@ -1170,7 +1331,13 @@ class SolanaHeliusGetActiveListingsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["first_verified_creators"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            
             first_verified_creators = data["first_verified_creators"]
             verified_collection_addresses = data.get("verified_collection_addresses", [])
             marketplaces = data.get("marketplaces", [])
@@ -1216,7 +1383,13 @@ class SolanaHeliusGetNFTMetadataTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["mint_accounts"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["mint_accounts"], list) or not all(isinstance(account, str) for account in data["mint_accounts"]):
+                raise ValueError("mint_accounts must be a list of strings") 
             mint_accounts = data["mint_accounts"]
 
             result = await self.solana_kit.get_nft_metadata(mint_accounts)
@@ -1263,7 +1436,15 @@ class SolanaHeliusGetRawTransactionsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["accounts"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["accounts"], list) or not all(isinstance(account, str) for account in data["accounts"]):
+                raise ValueError("accounts must be a list of strings")
+            
+
             accounts = data["accounts"]
             start_slot = data.get("start_slot", None)
             end_slot = data.get("end_slot", None)
@@ -1313,7 +1494,16 @@ class SolanaHeliusGetParsedTransactionsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["transactions"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["transactions"], list) or not all(isinstance(tx, str) for tx in data["transactions"]):
+                raise ValueError("transactions must be a list of strings")
+            if "commitment" in data and not isinstance(data["commitment"], str):
+                raise ValueError("commitment must be a string")
+            
             transactions = data["transactions"]
             commitment = data.get("commitment", None)
 
@@ -1359,7 +1549,24 @@ class SolanaHeliusGetParsedTransactionHistoryTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["address"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["address"], str):
+                raise ValueError("address must be a string")
+            if "before" in data and not isinstance(data["before"], str):
+                raise ValueError("before must be a string")
+            if "until" in data and not isinstance(data["until"], str):
+                raise ValueError("until must be a string")
+            if "commitment" in data and not isinstance(data["commitment"], str):
+                raise ValueError("commitment must be a string")
+            if "source" in data and not isinstance(data["source"], str):
+                raise ValueError("source must be a string")
+            if "type" in data and not isinstance(data["type"], str):
+                raise ValueError("type must be a string")
+            
             address = data["address"]
             before = data.get("before", "")
             until = data.get("until", "")
@@ -1411,7 +1618,24 @@ class SolanaHeliusCreateWebhookTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["webhook_url", "transaction_types", "account_addresses", "webhook_type"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["webhook_url"], str):
+                raise ValueError("webhook_url must be a string")
+            if not isinstance(data["transaction_types"], list) or not all(isinstance(tx, str) for tx in data["transaction_types"]):
+                raise ValueError("transaction_types must be a list of strings")
+            if not isinstance(data["account_addresses"], list) or not all(isinstance(account, str) for account in data["account_addresses"]):
+                raise ValueError("account_addresses must be a list of strings")
+            if not isinstance(data["webhook_type"], str):
+                raise ValueError("webhook_type must be a string")
+            if "txn_status" in data and not isinstance(data["txn_status"], str):
+                raise ValueError("txn_status must be a string")
+            if "auth_header" in data and not isinstance(data["auth_header"], str):
+                raise ValueError("auth_header must be a string")
+
             webhook_url = data["webhook_url"]
             transaction_types = data["transaction_types"]
             account_addresses = data["account_addresses"]
@@ -1453,7 +1677,7 @@ class SolanaHeliusGetAllWebhooksTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             result = await self.solana_kit.get_all_webhooks()
             return {
@@ -1492,7 +1716,15 @@ class SolanaHeliusGetWebhookTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["webhook_id"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["webhook_id"], str):
+                raise ValueError("webhook_id must be a string")
+
             webhook_id = data["webhook_id"]
 
             result = await self.solana_kit.get_webhook(webhook_id)
@@ -1537,7 +1769,27 @@ class SolanaHeliusEditWebhookTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["webhook_id", "webhook_url", "transaction_types", "account_addresses", "webhook_type"]   
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["webhook_id"], str):
+                raise ValueError("webhook_id must be a string")
+            if not isinstance(data["webhook_url"], str):
+                raise ValueError("webhook_url must be a string")
+            if not isinstance(data["transaction_types"], list) or not all(isinstance(tx, str) for tx in data["transaction_types"]):
+                raise ValueError("transaction_types must be a list of strings")
+            if not isinstance(data["account_addresses"], list) or not all(isinstance(account, str) for account in data["account_addresses"]):
+                raise ValueError("account_addresses must be a list of strings")
+            if not isinstance(data["webhook_type"], str):
+                raise ValueError("webhook_type must be a string")
+            
+            if "auth_header" in data and not isinstance(data["auth_header"], str):
+                raise ValueError("auth_header must be a string")
+            if "txn_status" in data and not isinstance(data["txn_status"], str):
+                raise ValueError("txn_status must be a string")
+            
             webhook_id = data["webhook_id"]
             webhook_url = data["webhook_url"]
             transaction_types = data["transaction_types"]
@@ -1585,7 +1837,15 @@ class SolanaHeliusDeleteWebhookTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+
+            required_fields = ["webhook_id"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["webhook_id"], str):
+                raise ValueError("webhook_id must be a string")
+
             webhook_id = data["webhook_id"]
 
             result = await self.solana_kit.delete_webhook(webhook_id)
@@ -1628,10 +1888,16 @@ class SolanaFetchTokenReportSummaryTool(BaseTool):
         Asynchronous implementation of the tool.
         """
         try:
-            data = json.loads(input)
-            mint = data.get("mint")
-            if not mint:
-                raise ValueError("Missing 'mint' in input.")
+            required_fields = ["mint"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["mint"], str):
+                raise ValueError("mint must be a string")
+            
+            mint = data["mint"]
             
             result = self.solana_kit.fetch_token_report_summary(mint)
             return {
@@ -1719,12 +1985,19 @@ class SolanaGetPumpCurveStateTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
-        try:
-            data = json.loads(input)
-            conn = data.get("conn")
-            curve_address = data.get("curve_address")
-            if not conn or not curve_address:
-                raise ValueError("Missing 'conn' or 'curve_address' in input.")
+        try:    
+            required_fields = ["conn", "curve_address"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["conn"], str):
+                raise ValueError("conn must be a string")
+            if not isinstance(data["curve_address"], str):
+                raise ValueError("curve_address must be a string")
+            conn = data["conn"]
+            curve_address = data["curve_address"]
+
 
             curve_address_key = Pubkey(curve_address)
             result = await self.solana_kit.get_pump_curve_state(conn, curve_address_key)
@@ -1761,10 +2034,14 @@ class SolanaCalculatePumpCurvePriceTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
-            curve_state = data.get("curve_state")
-            if not curve_state:
-                raise ValueError("Missing 'curve_state' in input.")
+            required_fields = ["curve_state"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["curve_state"], str):
+                raise ValueError("curve_state must be a string")
+            curve_state = data["curve_state"]
 
             result = await self.solana_kit.calculate_pump_curve_price(curve_state)
             return {
@@ -1777,7 +2054,7 @@ class SolanaCalculatePumpCurvePriceTool(BaseTool):
                 "message": str(e),
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution.")
 
 class SolanaBuyTokenTool(BaseTool):
@@ -1805,11 +2082,23 @@ class SolanaBuyTokenTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
-            required_keys = ["mint", "bonding_curve", "associated_bonding_curve", "amount", "slippage", "max_retries"]
-            for key in required_keys:
-                if key not in data:
-                    raise ValueError(f"Missing '{key}' in input.")
+            required_fields = ["mint", "bonding_curve", "associated_bonding_curve", "amount", "slippage", "max_retries"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["mint"], str):
+                raise ValueError("mint must be a string")
+            if not isinstance(data["bonding_curve"], str):
+                raise ValueError("bonding_curve must be a string")
+            if not isinstance(data["associated_bonding_curve"], str):
+                raise ValueError("associated_bonding_curve must be a string")
+            if not isinstance(data["amount"], int):
+                raise ValueError("amount must be an integer")
+            if not isinstance(data["slippage"], float):
+                raise ValueError("slippage must be a float")
+            if not isinstance(data["max_retries"], int):
+                raise ValueError("max_retries must be an integer")
 
             mint = Pubkey(data["mint"])
             bonding_curve = Pubkey(data["bonding_curve"])
@@ -1858,12 +2147,25 @@ class SolanaSellTokenTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
-        try:
-            data = json.loads(input)
-            required_keys = ["mint", "bonding_curve", "associated_bonding_curve", "amount", "slippage", "max_retries"]
-            for key in required_keys:
-                if key not in data:
-                    raise ValueError(f"Missing '{key}' in input.")
+        try:    
+            required_fields = ["mint", "bonding_curve", "associated_bonding_curve", "amount", "slippage", "max_retries"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["mint"], str):
+                raise ValueError("mint must be a string")
+            if not isinstance(data["bonding_curve"], str):
+                raise ValueError("bonding_curve must be a string")
+            if not isinstance(data["associated_bonding_curve"], str):
+                raise ValueError("associated_bonding_curve must be a string")
+            if not isinstance(data["amount"], int):
+                raise ValueError("amount must be an integer")
+            if not isinstance(data["slippage"], float):
+                raise ValueError("slippage must be a float")
+            if not isinstance(data["max_retries"], int):
+                raise ValueError("max_retries must be an integer")
 
             mint = Pubkey(data["mint"])
             bonding_curve = Pubkey(data["bonding_curve"])
@@ -1908,7 +2210,15 @@ class SolanaSNSResolveTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["domain"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["domain"], str):
+                raise ValueError("domain must be a string")
+            
             domain = data["domain"]
             if not domain:
                 raise ValueError("Domain is required.")
@@ -1954,16 +2264,30 @@ class SolanaSNSRegisterDomainTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["domain", "buyer", "buyer_token_account", "space"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["domain"], str):
+                raise ValueError("domain must be a string")
+            if not isinstance(data["buyer"], str):
+                raise ValueError("buyer must be a string")
+            if not isinstance(data["buyer_token_account"], str):
+                raise ValueError("buyer_token_account must be a string")
+            if not isinstance(data["space"], int):
+                raise ValueError("space must be an integer")
+            if "mint" in data and not isinstance(data["mint"], str):
+                raise ValueError("mint must be a string")
+            if "referrer_key" in data and not isinstance(data["referrer_key"], str):
+                raise ValueError("referrer_key must be a string")
+            
             domain = data["domain"]
             buyer = data["buyer"]
             buyer_token_account = data["buyer_token_account"]
             space = data["space"]
             mint = data.get("mint")
             referrer_key = data.get("referrer_key")
-
-            if not all([domain, buyer, buyer_token_account, space]):
-                raise ValueError("Domain, buyer, buyer_token_account, and space are required.")
 
             transaction = await self.solana_kit.get_registration_transaction(
                 domain, buyer, buyer_token_account, space, mint, referrer_key
@@ -2003,7 +2327,15 @@ class SolanaSNSGetFavouriteDomainTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["owner"]
+            data = toJSON(input)
+            
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["owner"], str):
+                raise ValueError("owner must be a string")
+            
             owner = data["owner"]
             if not owner:
                 raise ValueError("Owner address is required.")
@@ -2044,11 +2376,16 @@ class SolanaSNSGetAllDomainsTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["owner"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["owner"], str):
+                raise ValueError("owner must be a string")
+            
             owner = data["owner"]
-            if not owner:
-                raise ValueError("Owner address is required.")
-
+            
             domains = await self.solana_kit.get_all_domains_for_owner(owner)
             return {
                 "domains": domains or [],
@@ -2089,14 +2426,26 @@ class SolanaDeployCollectionTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["name", "uri", "royalty_basis_points", "creator_address"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["name"], str):
+                raise ValueError("name must be a string")
+            if not isinstance(data["uri"], str):
+                raise ValueError("uri must be a string")
+            if not isinstance(data["royalty_basis_points"], int):
+                raise ValueError("royalty_basis_points must be an integer")
+            if not isinstance(data["creator_address"], str):
+                raise ValueError("creator_address must be a string")
+
             name = data["name"]
             uri = data["uri"]
             royalty_basis_points = data["royalty_basis_points"]
             creator_address = data["creator_address"]
 
-            if not all([name, uri, royalty_basis_points, creator_address]):
-                raise ValueError("All input fields are required.")
+           
 
             result = await self.solana_kit.deploy_collection(
                 name=name,
@@ -2132,11 +2481,18 @@ class SolanaGetMetaplexAssetTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["asset_id"]
+            data = toJSON(input)
+            
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["asset_id"], str):
+                raise ValueError("asset_id must be a string")
+            
             asset_id = data["asset_id"]
 
-            if not asset_id:
-                raise ValueError("Asset ID is required.")
+            
 
             result = await self.solana_kit.get_metaplex_asset(asset_id)
             return result
@@ -2172,7 +2528,25 @@ class SolanaGetMetaplexAssetsByCreatorTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["creator", "only_verified", "sort_by", "sort_direction", "limit", "page"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["creator"], str):
+                raise ValueError("creator must be a string")
+            if not isinstance(data["only_verified"], bool):
+                raise ValueError("only_verified must be a boolean")
+            if not isinstance(data["sort_by"], str):
+                raise ValueError("sort_by must be a string")
+            if not isinstance(data["sort_direction"], str):
+                raise ValueError("sort_direction must be a string")
+            if not isinstance(data["limit"], int):
+                raise ValueError("limit must be an integer")
+            if not isinstance(data["page"], int):
+                raise ValueError("page must be an integer")
+            
             creator = data["creator"]
             only_verified = data.get("only_verified", False)
             sort_by = data.get("sort_by")
@@ -2180,9 +2554,7 @@ class SolanaGetMetaplexAssetsByCreatorTool(BaseTool):
             limit = data.get("limit")
             page = data.get("page")
 
-            if not creator:
-                raise ValueError("Creator address is required.")
-
+            
             result = await self.solana_kit.get_metaplex_assets_by_creator(
                 creator=creator,
                 onlyVerified=only_verified,
@@ -2224,16 +2596,30 @@ class SolanaGetMetaplexAssetsByAuthorityTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["authority", "sort_by", "sort_direction", "limit", "page"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["authority"], str):
+                raise ValueError("authority must be a string")
+            if not isinstance(data["sort_by"], str):
+                raise ValueError("sort_by must be a string")
+            if not isinstance(data["sort_direction"], str):
+                raise ValueError("sort_direction must be a string")
+            if not isinstance(data["limit"], int):
+                raise ValueError("limit must be an integer")
+            if not isinstance(data["page"], int):
+                raise ValueError("page must be an integer")
+            
             authority = data["authority"]
             sort_by = data.get("sort_by")
             sort_direction = data.get("sort_direction")
             limit = data.get("limit")
             page = data.get("page")
 
-            if not authority:
-                raise ValueError("Creator address is required.")
-
+            
             result = await self.solana_kit.get_metaplex_assets_by_authority(
                 authority=authority,
                 sortBy=sort_by,
@@ -2275,17 +2661,34 @@ class SolanaMintMetaplexCoreNFTTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["collection_mint", "name", "uri", "seller_fee_basis_points", "address", "share", "recipient"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["collection_mint"], str):
+                raise ValueError("collection_mint must be a string")
+            if not isinstance(data["name"], str):
+                raise ValueError("name must be a string")
+            if not isinstance(data["uri"], str):
+                raise ValueError("uri must be a string")
+            if not isinstance(data["seller_fee_basis_points"], int):
+                raise ValueError("seller_fee_basis_points must be an integer")
+            if not isinstance(data["address"], str):
+                raise ValueError("address must be a string")
+            if not isinstance(data["share"], str):
+                raise ValueError("share must be a string")
+            if not isinstance(data["recipient"], str):
+                raise ValueError("recipient must be a string")
+            
             collection_mint = data["collection_mint"]
             name = data["name"]
             uri = data["uri"]
-            seller_fee_basis_points = data.get("seller_fee_basis_points")
-            address = data.get("address")
-            share = data.get("share")
-            recipient = data.get("recipient")
-
-            if not all([collection_mint, name, uri]):
-                raise ValueError("Collection mint, name, and URI are required.")
+            seller_fee_basis_points = data["seller_fee_basis_points"]
+            address = data["address"]
+            share = data["share"]
+            recipient = data["recipient"]
 
             result = await self.solana_kit.mint_metaplex_core_nft(
                 collectionMint=collection_mint,
@@ -2334,7 +2737,29 @@ class SolanaDeBridgeCreateTransactionTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["src_chain_id", "src_chain_token_in", "src_chain_token_in_amount", "dst_chain_id", "dst_chain_token_out", "dst_chain_token_out_recipient", "src_chain_order_authority_address", "dst_chain_order_authority_address", "affiliate_fee_percent", "affiliate_fee_recipient", "prepend_operating_expenses", "dst_chain_token_out_amount"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["src_chain_id"], str):
+                raise ValueError("src_chain_id must be a string")
+            if not isinstance(data["src_chain_token_in"], str):
+                raise ValueError("src_chain_token_in must be a string")
+            if not isinstance(data["src_chain_token_in_amount"], str):
+                raise ValueError("src_chain_token_in_amount must be a string")
+            if not isinstance(data["dst_chain_id"], str):
+                raise ValueError("dst_chain_id must be a string")
+            if not isinstance(data["dst_chain_token_out"], str):
+                raise ValueError("dst_chain_token_out must be a string")
+            if not isinstance(data["dst_chain_token_out_recipient"], str):
+                raise ValueError("dst_chain_token_out_recipient must be a string")
+            if not isinstance(data["src_chain_order_authority_address"], str):
+                raise ValueError("src_chain_order_authority_address must be a string")
+            if not isinstance(data["dst_chain_order_authority_address"], str):
+                raise ValueError("dst_chain_order_authority_address must be a string")
+            
             transaction_data = await self.solana_kit.create_debridge_transaction(
                 src_chain_id=data["src_chain_id"],
                 src_chain_token_in=data["src_chain_token_in"],
@@ -2384,10 +2809,16 @@ class SolanaDeBridgeExecuteTransactionTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["transaction_data"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["transaction_data"], dict):
+                raise ValueError("transaction_data must be a dictionary")
+            
             transaction_data = data["transaction_data"]
-            if not transaction_data:
-                raise ValueError("Transaction data is required.")
 
             result = await self.solana_kit.execute_debridge_transaction(transaction_data)
             return {
@@ -2425,10 +2856,17 @@ class SolanaDeBridgeCheckTransactionStatusTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["tx_hash"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["tx_hash"], str):
+                raise ValueError("tx_hash must be a string")
+            
             tx_hash = data["tx_hash"]
-            if not tx_hash:
-                raise ValueError("Transaction hash is required.")
+
 
             status = await self.solana_kit.check_transaction_status(tx_hash)
             return {
@@ -2470,16 +2908,30 @@ class SolanaCybersCreateCoinTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["name", "symbol", "image_path", "tweet_author_id", "tweet_author_username"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["name"], str):
+                raise ValueError("name must be a string")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if not isinstance(data["image_path"], str):
+                raise ValueError("image_path must be a string")
+            if not isinstance(data["tweet_author_id"], str):
+                raise ValueError("tweet_author_id must be a string")
+            if not isinstance(data["tweet_author_username"], str):
+                raise ValueError("tweet_author_username must be a string")
+            
             name = data["name"]
             symbol = data["symbol"]
             image_path = data["image_path"]
             tweet_author_id = data["tweet_author_id"]
             tweet_author_username = data["tweet_author_username"]
 
-            if not all([name, symbol, image_path, tweet_author_id, tweet_author_username]):
-                raise ValueError("All fields (name, symbol, image_path, tweet_author_id, tweet_author_username) are required.")
-
+            
             coin_id = await self.solana_kit.cybers_create_coin(
                 name=name,
                 symbol=symbol,
@@ -2514,7 +2966,7 @@ class SolanaGetTipAccounts(BaseTool):
     """
     solana_kit: SolanaAgentKit
     
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             result = await self.solana_kit.get_tip_accounts()
             return {
@@ -2542,7 +2994,7 @@ class SolanaGetRandomTipAccount(BaseTool):
     """
     solana_kit: SolanaAgentKit
     
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             result = await self.solana_kit.get_random_tip_account()
             return {
@@ -2553,7 +3005,7 @@ class SolanaGetRandomTipAccount(BaseTool):
                 "account": None
             }
     
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError(
             "This tool only supports async execution via _arun. Please use the async interface."
         )
@@ -2562,6 +3014,11 @@ class SolanaGetBundleStatuses(BaseTool):
     name: str = "get_bundle_statuses"
     description: str = """
     Get the current statuses of specified Jito bundles.
+
+    Input: A JSON string with:
+    {
+        "bundle_uuids": "List of bundle UUIDs"
+    }
 
     Output:
     {
@@ -2572,7 +3029,16 @@ class SolanaGetBundleStatuses(BaseTool):
     
     async def _arun(self, input: str):
         try:
-            bundle_uuids = input["bundle_uuids"]
+            required_fields = ["bundle_uuids"]  
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["bundle_uuids"], list):
+                raise ValueError("bundle_uuids must be a list")
+            
+            bundle_uuids = data["bundle_uuids"]
             result = await self.solana_kit.get_bundle_statuses(bundle_uuids)
             return {
                 "statuses": result
@@ -2582,7 +3048,7 @@ class SolanaGetBundleStatuses(BaseTool):
                 "statuses": None
             }
     
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError(
             "This tool only supports async execution via _arun. Please use the async interface."
         )
@@ -2591,6 +3057,11 @@ class SolanaSendBundle(BaseTool):
     name: str = "send_bundle"
     description: str = """
     Send a bundle of transactions to the Jito network for processing.
+
+    Input: A JSON string with:
+    {
+        "txn_signatures": "List of transaction signatures"
+    }
 
     Output:
     {
@@ -2601,8 +3072,17 @@ class SolanaSendBundle(BaseTool):
     
     async def _arun(self, input: str):
         try:
-            params = input["txn_signatures"]
-            result = await self.solana_kit.send_bundle(params)
+            required_fields = ["txn_signatures"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["txn_signatures"], list):
+                raise ValueError("txn_signatures must be a list")
+            
+            txn_signatures = data["txn_signatures"]
+            result = await self.solana_kit.send_bundle(txn_signatures)
             return {
                 "bundle_ids": result
             }
@@ -2611,7 +3091,7 @@ class SolanaSendBundle(BaseTool):
                 "bundle_ids": None
             }
     
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError(
             "This tool only supports async execution via _arun. Please use the async interface."
         )
@@ -2620,6 +3100,11 @@ class SolanaGetInflightBundleStatuses(BaseTool):
     name: str = "get_inflight_bundle_statuses"
     description: str = """
     Get the statuses of bundles that are currently in flight.
+
+    Input: A JSON string with:
+    {
+        "bundle_uuids": "List of bundle UUIDs"
+    }
 
     Output:
     {
@@ -2630,7 +3115,16 @@ class SolanaGetInflightBundleStatuses(BaseTool):
     
     async def _arun(self, input: str):
         try:
-            bundle_uuids = input["bundle_uuids"]
+            required_fields = ["bundle_uuids"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["bundle_uuids"], list):
+                raise ValueError("bundle_uuids must be a list")
+            
+            bundle_uuids = data["bundle_uuids"]
             result = await self.solana_kit.get_inflight_bundle_statuses(bundle_uuids)
             return {
                 "statuses": result
@@ -2640,7 +3134,7 @@ class SolanaGetInflightBundleStatuses(BaseTool):
                 "statuses": None
             }
     
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError(
             "This tool only supports async execution via _arun. Please use the async interface."
         )
@@ -2649,6 +3143,12 @@ class SolanaSendTxn(BaseTool):
     name: str = "send_txn"
     description: str = """
     Send an individual transaction to the Jito network for processing.
+
+    Input: A JSON string with:
+    {
+        "txn_signature": "string, the transaction signature",
+        "bundleOnly": "boolean, whether to send the transaction as a bundle"
+    }
 
     Output:
     {
@@ -2659,9 +3159,20 @@ class SolanaSendTxn(BaseTool):
     
     async def _arun(self, input: str):
         try:
-            params = [input["txn_signature"]]
-            bundleOnly = input["bundleOnly"]
-            result = await self.solana_kit.send_txn(params, bundleOnly)
+            required_fields = ["txn_signature", "bundleOnly"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["txn_signature"], str):
+                raise ValueError("txn_signature must be a string")
+            if not isinstance(data["bundleOnly"], bool):
+                raise ValueError("bundleOnly must be a boolean")
+            
+            txn_signature = data["txn_signature"]
+            bundleOnly = data["bundleOnly"]
+            result = await self.solana_kit.send_txn(txn_signature, bundleOnly)
             return {
                 "status": result
             }
@@ -2670,7 +3181,7 @@ class SolanaSendTxn(BaseTool):
                 "status": None
             }
     
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError(
             "This tool only supports async execution via _arun. Please use the async interface."
         )
@@ -2688,7 +3199,7 @@ class BackpackGetAccountBalancesTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             balances = await self.solana_kit.get_account_balances()
             return {
@@ -2701,7 +3212,7 @@ class BackpackGetAccountBalancesTool(BaseTool):
                 "message": f"Error fetching account balances: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackRequestWithdrawalTool(BaseTool):
@@ -2727,7 +3238,21 @@ class BackpackRequestWithdrawalTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["address", "blockchain", "quantity", "symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["address"], str):
+                raise ValueError("address must be a string")
+            if not isinstance(data["blockchain"], str):
+                raise ValueError("blockchain must be a string")
+            if not isinstance(data["quantity"], str):
+                raise ValueError("quantity must be a string")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             result = await self.solana_kit.request_withdrawal(
                 address=data["address"],
                 blockchain=data["blockchain"],
@@ -2762,7 +3287,7 @@ class BackpackGetAccountSettingsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             settings = await self.solana_kit.get_account_settings()
             return {
@@ -2823,7 +3348,7 @@ class BackpackGetBorrowLendPositionsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             positions = await self.solana_kit.get_borrow_lend_positions()
             return {
@@ -2860,7 +3385,19 @@ class BackpackExecuteBorrowLendTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["quantity", "side", "symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["quantity"], str):
+                raise ValueError("quantity must be a string")
+            if not isinstance(data["side"], str):
+                raise ValueError("side must be a string")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             result = await self.solana_kit.execute_borrow_lend(
                 quantity=data["quantity"],
                 side=data["side"],
@@ -2876,7 +3413,7 @@ class BackpackExecuteBorrowLendTool(BaseTool):
                 "message": f"Error executing borrow/lend operation: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetFillHistoryTool(BaseTool):
@@ -3234,7 +3771,7 @@ class BackpackGetSupportedAssetsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             assets = await self.solana_kit.get_supported_assets()
             return {
@@ -3295,7 +3832,7 @@ class BackpackGetMarketsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             markets = await self.solana_kit.get_markets()
             return {
@@ -3356,7 +3893,7 @@ class BackpackGetTickersTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             tickers = await self.solana_kit.get_tickers()
             return {
@@ -3369,7 +3906,7 @@ class BackpackGetTickersTool(BaseTool):
                 "message": f"Error fetching tickers: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetDepthTool(BaseTool):
@@ -3391,7 +3928,11 @@ class BackpackGetDepthTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
             symbol = data["symbol"]
             depth = await self.solana_kit.get_depth(symbol)
             return {
@@ -3404,7 +3945,7 @@ class BackpackGetDepthTool(BaseTool):
                 "message": f"Error fetching depth: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetKlinesTool(BaseTool):
@@ -3429,7 +3970,18 @@ class BackpackGetKlinesTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol", "interval", "start_time"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["start_time"], int):
+                raise ValueError("start_time must be an integer")
+            if not isinstance(data["interval"], str):
+                raise ValueError("interval must be a string")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            
             klines = await self.solana_kit.get_klines(
                 symbol=data["symbol"],
                 interval=data["interval"],
@@ -3468,7 +4020,13 @@ class BackpackGetMarkPriceTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
             symbol = data["symbol"]
             mark_price_data = await self.solana_kit.get_mark_price(symbol)
             return {
@@ -3481,7 +4039,7 @@ class BackpackGetMarkPriceTool(BaseTool):
                 "message": f"Error fetching mark price: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetOpenInterestTool(BaseTool):
@@ -3503,7 +4061,13 @@ class BackpackGetOpenInterestTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
             symbol = data["symbol"]
             open_interest = await self.solana_kit.get_open_interest(symbol)
             return {
@@ -3516,7 +4080,7 @@ class BackpackGetOpenInterestTool(BaseTool):
                 "message": f"Error fetching open interest: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetFundingIntervalRatesTool(BaseTool):
@@ -3540,7 +4104,19 @@ class BackpackGetFundingIntervalRatesTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if "limit" in data and not isinstance(data["limit"], int):
+                raise ValueError("limit must be an integer")
+            if "offset" in data and not isinstance(data["offset"], int):
+                raise ValueError("offset must be an integer")
+            
             funding_rates = await self.solana_kit.get_funding_interval_rates(
                 symbol=data["symbol"],
                 limit=data.get("limit", 100),
@@ -3556,7 +4132,7 @@ class BackpackGetFundingIntervalRatesTool(BaseTool):
                 "message": f"Error fetching funding interval rates: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetStatusTool(BaseTool):
@@ -3573,7 +4149,7 @@ class BackpackGetStatusTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             status = await self.solana_kit.get_status()
             return {
@@ -3586,7 +4162,7 @@ class BackpackGetStatusTool(BaseTool):
                 "message": f"Error fetching system status: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackSendPingTool(BaseTool):
@@ -3603,7 +4179,7 @@ class BackpackSendPingTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             response = await self.solana_kit.send_ping()
             return {
@@ -3633,7 +4209,7 @@ class BackpackGetSystemTimeTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             system_time = await self.solana_kit.get_system_time()
             return {
@@ -3646,7 +4222,7 @@ class BackpackGetSystemTimeTool(BaseTool):
                 "message": f"Error fetching system time: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetRecentTradesTool(BaseTool):
@@ -3669,7 +4245,16 @@ class BackpackGetRecentTradesTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if "limit" in data and not isinstance(data["limit"], int):
+                raise ValueError("limit must be an integer")
+            
             recent_trades = await self.solana_kit.get_recent_trades(
                 symbol=data["symbol"],
                 limit=data.get("limit", 100)
@@ -3684,7 +4269,7 @@ class BackpackGetRecentTradesTool(BaseTool):
                 "message": f"Error fetching recent trades: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetHistoricalTradesTool(BaseTool):
@@ -3708,7 +4293,19 @@ class BackpackGetHistoricalTradesTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["symbol"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["symbol"], str):
+                raise ValueError("symbol must be a string")
+            if "limit" in data and not isinstance(data["limit"], int):
+                raise ValueError("limit must be an integer")
+            if "offset" in data and not isinstance(data["offset"], int):
+                raise ValueError("offset must be an integer")
+            
             historical_trades = await self.solana_kit.get_historical_trades(
                 symbol=data["symbol"],
                 limit=data.get("limit", 100),
@@ -3724,7 +4321,7 @@ class BackpackGetHistoricalTradesTool(BaseTool):
                 "message": f"Error fetching historical trades: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetCollateralInfoTool(BaseTool):
@@ -3746,7 +4343,11 @@ class BackpackGetCollateralInfoTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            
+            data = toJSON(input)
+            if "sub_account_id" in data and not isinstance(data["sub_account_id"], int):
+                raise ValueError("sub_account_id must be an integer")
+            
             collateral_info = await self.solana_kit.get_collateral_info(
                 sub_account_id=data.get("sub_account_id")
             )
@@ -3760,7 +4361,7 @@ class BackpackGetCollateralInfoTool(BaseTool):
                 "message": f"Error fetching collateral information: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetAccountDepositsTool(BaseTool):
@@ -3808,7 +4409,7 @@ class BackpackGetOpenPositionsTool(BaseTool):
     """
     solana_kit: SolanaAgentKit
 
-    async def _arun(self, input: str):
+    async def _arun(self):
         try:
             open_positions = await self.solana_kit.get_open_positions()
             return {
@@ -3821,7 +4422,7 @@ class BackpackGetOpenPositionsTool(BaseTool):
                 "message": f"Error fetching open positions: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class BackpackGetBorrowHistoryTool(BaseTool):
@@ -3883,7 +4484,7 @@ class BackpackGetInterestHistoryTool(BaseTool):
                 "message": f"Error fetching interest history: {str(e)}"
             }
 
-    def _run(self, input: str):
+    def _run(self):
         raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class ClosePerpTradeShortTool(BaseTool):
@@ -3906,7 +4507,17 @@ class ClosePerpTradeShortTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["price", "trade_mint"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+            if not isinstance(data["trade_mint"], str):
+                raise ValueError("trade_mint must be a string")
+            
             transaction = await self.solana_kit.close_perp_trade_short(
                 price=data["price"],
                 trade_mint=data["trade_mint"]
@@ -3921,8 +4532,8 @@ class ClosePerpTradeShortTool(BaseTool):
                 "message": f"Error closing perp short trade: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class ClosePerpTradeLongTool(BaseTool):
     name: str = "close_perp_trade_long"
@@ -3944,7 +4555,17 @@ class ClosePerpTradeLongTool(BaseTool):
 
     async def _arun(self, input: str):
         try:
-            data = json.loads(input)
+            required_fields = ["price", "trade_mint"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+            if not isinstance(data["trade_mint"], str):
+                raise ValueError("trade_mint must be a string")
+            
             transaction = await self.solana_kit.close_perp_trade_long(
                 price=data["price"],
                 trade_mint=data["trade_mint"]
@@ -3959,8 +4580,8 @@ class ClosePerpTradeLongTool(BaseTool):
                 "message": f"Error closing perp long trade: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class OpenPerpTradeLongTool(BaseTool):
     name: str = "open_perp_trade_long"
@@ -3985,8 +4606,26 @@ class OpenPerpTradeLongTool(BaseTool):
     solana_kit: SolanaAgentKit
 
     async def _arun(self, input: str):
-        try:
-            data = json.loads(input)
+        try:    
+            required_fields = ["price", "collateral_amount"]
+            data = toJSON(input)
+
+            for field in required_fields:
+                if field not in data:
+                    raise ValueError(f"Missing required field: {field}")
+            if not isinstance(data["price"], float):
+                raise ValueError("price must be a float")
+            if not isinstance(data["collateral_amount"], float):
+                raise ValueError("collateral_amount must be a float")
+            if "collateral_mint" in data and not isinstance(data["collateral_mint"], str):
+                raise ValueError("collateral_mint must be a string")
+            if "leverage" in data and not isinstance(data["leverage"], float):
+                raise ValueError("leverage must be a float")
+            if "trade_mint" in data and not isinstance(data["trade_mint"], str):
+                raise ValueError("trade_mint must be a string")
+            if "slippage" in data and not isinstance(data["slippage"], float):
+                raise ValueError("slippage must be a float")
+            
             transaction = await self.solana_kit.open_perp_trade_long(
                 price=data["price"],
                 collateral_amount=data["collateral_amount"],
@@ -4005,8 +4644,8 @@ class OpenPerpTradeLongTool(BaseTool):
                 "message": f"Error opening perp long trade: {str(e)}"
             }
 
-    def _run(self, input: str):
-        raise NotImplementedError("This tool only supports async execution via _arun.")
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
 
 class OpenPerpTradeShortTool(BaseTool):
     name: str = "open_perp_trade_short"

--- a/agentipy/utils/raydium/utils.py
+++ b/agentipy/utils/raydium/utils.py
@@ -85,8 +85,22 @@ def bytes_of(value):
     return struct.pack('<Q', value)
 
 def get_pair_address_from_api(mint):
-    url = f"https://api-v3.raydium.io/pools/info/mint?mint1={mint}&poolType=all&poolSortField=default&sortType=desc&pageSize=1&page=1"
+    """
+    Fetches pair address from Raydium API.
+    
+    Args:
+        mint: Token mint address
+        
+    Returns:
+        Optional[str]: Pair address if found, None otherwise
+    """
+    schema = {
+        "mint": {"type": str, "required": True}
+    }
+    
     try:
+        validate_input({"mint": mint}, schema)
+        url = f"https://api-v3.raydium.io/pools/info/mint?mint1={mint}&poolType=all&poolSortField=default&sortType=desc&pageSize=1&page=1"
         response = requests.get(url)
         response.raise_for_status()
         data = response.json()
@@ -144,7 +158,30 @@ def make_swap_instruction(
         accounts: PoolKeys,
         owner:Keypair
 ) -> Instruction:
+    """
+    Creates a swap instruction for Raydium.
+    
+    Args:
+        amount_in: Amount of input token
+        minimum_amount_out: Minimum amount of output token
+        token_account_in: Input token account
+        token_account_out: Output token account
+        accounts: Pool keys
+        owner: Owner keypair
+        
+    Returns:
+        Optional[Instruction]: Swap instruction if successful, None otherwise
+    """
+    schema = {
+        "amount_in": {"type": int, "required": True},
+        "minimum_amount_out": {"type": int, "required": True},
+    }
     try:
+        validate_input({
+            "amount_in": amount_in,
+            "minimum_amount_out": minimum_amount_out
+        }, schema)
+        
         keys = [
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=accounts.amm_id, is_signer=False, is_writable=True),
@@ -178,7 +215,21 @@ def make_swap_instruction(
         return None
 
 def get_token_balance(agent: SolanaAgentKit, mint_str: str) -> float | None:
+    """
+    Gets token balance for a given mint.
+    
+    Args:
+        agent: SolanaAgentKit instance
+        mint_str: Token mint address
+        
+    Returns:
+        Optional[float]: Token balance if found, None otherwise
+    """
+    schema = {
+        "mint_str": {"type": str, "required": True}
+    }
     try:
+        validate_input({"mint_str": mint_str}, schema)
         mint = PublicKey.from_string(mint_str)
         response = agent.connection.get_account_info_json_parsed(
             agent.wallet_address,


### PR DESCRIPTION
feat: Implement validate_input helper function for consistent input validation
This commit introduces a new validate_input helper function in the agentipy.helpers module to standardize input validation across Solana tools. The function provides a flexible schema-based validation mechanism that checks:

- Required fields
- Field types
- Numeric ranges
- Optional constraints

The implementation replaces manual input validation logic in multiple Solana tools, reducing code duplication and improving consistency in error handling and input processing.