### PR TITLE
Feat extend evm privy

### DIFF
--- a/agentipy/agent/__init__.py
+++ b/agentipy/agent/__init__.py
@@ -3,8 +3,11 @@ import os
 from typing import Any, Dict, List, Optional
 
 import base58
-from allora_sdk.v2.api_client import (PriceInferenceTimeframe,
-                                      PriceInferenceToken, SignatureFormat)
+from allora_sdk.v2.api_client import (
+    PriceInferenceTimeframe,
+    PriceInferenceToken,
+    SignatureFormat,
+)
 from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient
 from solders.keypair import Keypair  # type: ignore
@@ -15,9 +18,12 @@ from agentipy.constants import API_VERSION, BASE_PROXY_URL, DEFAULT_OPTIONS
 from agentipy.types import BondingCurveState, PumpfunTokenOptions
 from agentipy.utils import AgentKitError
 from agentipy.utils.meteora_dlmm.types import ActivationType
+from agentipy.wallet.base_wallet_client import BaseWalletClient
 from agentipy.wallet.solana_wallet_client import SolanaWalletClient
+from agentipy.wallet.privy_wallet_client import PrivyWalletClient
 
 logger = logging.getLogger(__name__)
+
 
 class SolanaAgentKit:
     """
@@ -25,7 +31,7 @@ class SolanaAgentKit:
 
     Attributes:
         connection (AsyncClient): Solana RPC connection.
-        wallet (SolanaWalletClient): Wallet client for signing and sending transactions.
+        wallet_client (BaseWalletClient): Wallet client for signing and sending transactions.
         wallet_address (Pubkey): Public key of the wallet.
     """
 
@@ -45,10 +51,14 @@ class SolanaAgentKit:
         coingecko_api_key: Optional[str] = None,
         coingecko_demo_api_key: Optional[str] = None,
         elfa_ai_api_key: Optional[str] = None,
-        flexland_api_key : Optional[str] = None,
+        flexland_api_key: Optional[str] = None,
         allora_api_key: Optional[str] = None,
         solutiofi_api_key: Optional[str] = None,
+        privy_app_id: Optional[str] = None,
+        privy_app_secret: Optional[str] = None,
+        privy_wallet_id: Optional[str] = None,
         generate_wallet: bool = False,
+        use_privy_wallet: bool = False,
     ):
         """
         Initialize the SolanaAgentKit.
@@ -62,51 +72,95 @@ class SolanaAgentKit:
             quicknode_rpc_url (str, optional): QuickNode RPC URL.
             jito_block_engine_url (str, optional): Jito block engine URL for Solana.
             jito_uuid (str, optional): Jito UUID for authentication.
+            privy_app_id (str, optional): Privy App ID for using Privy wallet.
+            privy_app_secret (str, optional): Privy App Secret for using Privy wallet.
             generate_wallet (bool): If True, generates a new wallet and returns the details.
+            use_privy_wallet (bool): If True, uses Privy wallet instead of local keypair.
         """
-        self.rpc_url = rpc_url or os.getenv("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+        self.rpc_url = rpc_url or os.getenv(
+            "SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com"
+        )
         self.openai_api_key = openai_api_key or os.getenv("OPENAI_API_KEY", "")
         self.helius_api_key = helius_api_key or os.getenv("HELIUS_API_KEY", "")
         self.helius_rpc_url = helius_rpc_url or os.getenv("HELIUS_RPC_URL", "")
         self.backpack_api_key = backpack_api_key or os.getenv("BACKPACK_API_KEY", "")
-        self.backpack_api_secret = backpack_api_secret or os.getenv("BACKPACK_API_SECRET", "")
+        self.backpack_api_secret = backpack_api_secret or os.getenv(
+            "BACKPACK_API_SECRET", ""
+        )
         self.quicknode_rpc_url = quicknode_rpc_url or os.getenv("QUICKNODE_RPC_URL", "")
-        self.jito_block_engine_url = jito_block_engine_url or os.getenv("JITO_BLOCK_ENGINE_URL", "")
+        self.jito_block_engine_url = jito_block_engine_url or os.getenv(
+            "JITO_BLOCK_ENGINE_URL", ""
+        )
         self.jito_uuid = jito_uuid or os.getenv("JITO_UUID", None)
         self.stork_api_key = stork_api_key or os.getenv("STORK_API_KEY", "")
-        self.coingecko_api_key = coingecko_api_key or os.getenv("COINGECKO_PRO_API_KEY", "")
-        self.coingecko_demo_api_key = coingecko_demo_api_key or os.getenv("COINGECKO_DEMO_API_KEY", "")
+        self.coingecko_api_key = coingecko_api_key or os.getenv(
+            "COINGECKO_PRO_API_KEY", ""
+        )
+        self.coingecko_demo_api_key = coingecko_demo_api_key or os.getenv(
+            "COINGECKO_DEMO_API_KEY", ""
+        )
         self.elfa_ai_api_key = elfa_ai_api_key or os.getenv("ELFA_AI_API_KEY", "")
         self.flexland_api_key = flexland_api_key or os.getenv("FLEXLAND_API_KEY", "")
         self.allora_api_key = allora_api_key or os.getenv("ALLORA_API_KEY", "")
         self.solutiofi_api_key = solutiofi_api_key or os.getenv("SOLUTIOFI_API_KEY", "")
+        self.privy_app_id = privy_app_id or os.getenv("PRIVY_APP_ID", "")
+        self.privy_app_secret = privy_app_secret or os.getenv("PRIVY_APP_SECRET", "")
         self.base_proxy_url = BASE_PROXY_URL
         self.api_version = API_VERSION
-
-        if generate_wallet:
-            self.wallet = Keypair()
-            self.wallet_address = self.wallet.pubkey()
-            self.private_key = base58.b58encode(self.wallet.secret()).decode("utf-8")
-        else:
-            self.private_key = private_key or os.getenv("SOLANA_PRIVATE_KEY", "")
-            self.wallet = Keypair.from_base58_string(self.private_key)
-            self.wallet_address = self.wallet.pubkey()
-
-        if not self.wallet or not self.wallet_address:
-            raise ValueError("A valid private key must be provided or a wallet must be generated.")
 
         self.connection = AsyncClient(self.rpc_url)
         self.connection_client = Client(self.rpc_url)
 
-        self.wallet_client = SolanaWalletClient(self.connection_client, self.wallet)
+        if use_privy_wallet:
+            if not self.privy_app_id or not self.privy_app_secret:
+                raise ValueError(
+                    "PRIVY_APP_ID and PRIVY_APP_SECRET must be provided to use Privy wallet."
+                )
 
-        if generate_wallet:
-            logger.info("New Wallet Generated:")
-            logger.info(f"Public Key: {self.wallet_address}")
-            logger.info(f"Private Key: {self.private_key}")
+            # Initialize Privy wallet
+            self.wallet_client = PrivyWalletClient(
+                self.connection_client,
+                self.privy_app_id,
+                self.privy_app_secret,
+            )
+
+            if generate_wallet:
+                wallet_info = self.wallet_client.create_wallet()
+                self.wallet_id = wallet_info["id"]
+                self.wallet_address = Pubkey.from_string(wallet_info["address"])
+            else:
+                wallet_address = self.wallet_client.use_wallet(privy_wallet_id)
+
+                self.wallet_id = privy_wallet_id
+                self.wallet_address = Pubkey.from_string(wallet_address)
+
+        else:
+            # Initialize local wallet with keypair
+            if generate_wallet:
+                self.wallet = Keypair()
+                self.wallet_address = self.wallet.pubkey()
+                self.private_key = base58.b58encode(self.wallet.secret()).decode(
+                    "utf-8"
+                )
+
+                logger.info("New Local Wallet Generated:")
+                logger.info(f"Public Key: {self.wallet_address}")
+                logger.info(f"Private Key: {self.private_key}")
+            else:
+                self.private_key = private_key or os.getenv("SOLANA_PRIVATE_KEY", "")
+                if not self.private_key:
+                    raise ValueError(
+                        "A valid private key must be provided or a wallet must be generated."
+                    )
+
+                self.wallet = Keypair.from_base58_string(self.private_key)
+                self.wallet_address = self.wallet.pubkey()
+
+            self.wallet_client = SolanaWalletClient(self.connection_client, self.wallet)
 
     async def request_faucet_funds(self):
         from agentipy.tools.request_faucet_funds import FaucetManager
+
         try:
             return await FaucetManager.request_faucet_funds(self)
         except Exception as e:
@@ -114,6 +168,7 @@ class SolanaAgentKit:
 
     async def deploy_token(self, decimals: int = DEFAULT_OPTIONS["TOKEN_DECIMALS"]):
         from agentipy.tools.deploy_token import TokenDeploymentManager
+
         try:
             return await TokenDeploymentManager.deploy_token(self, decimals)
         except Exception as e:
@@ -121,13 +176,15 @@ class SolanaAgentKit:
 
     async def get_balance(self, token_address: Optional[Pubkey] = None):
         from agentipy.tools.get_balance import BalanceFetcher
+
         try:
             return await BalanceFetcher.get_balance(self, token_address)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch balance: {e}")
-    
+
     async def fetch_price(self, token_id: str):
         from agentipy.tools.fetch_price import TokenPriceFetcher
+
         try:
             return await TokenPriceFetcher.fetch_price(token_id)
         except Exception as e:
@@ -135,25 +192,36 @@ class SolanaAgentKit:
 
     async def transfer(self, to: str, amount: float, mint: Optional[Pubkey] = None):
         from agentipy.tools.transfer import TokenTransferManager
+
         try:
             return await TokenTransferManager.transfer(self, to, amount, mint)
         except Exception as e:
             raise AgentKitError(f"Failed to execute transfer: {e}")
 
-    async def trade(self, output_mint: Pubkey, input_amount: float, input_mint: Optional[Pubkey] = None, slippage_bps: int = DEFAULT_OPTIONS["SLIPPAGE_BPS"]):
+    async def trade(
+        self,
+        output_mint: Pubkey,
+        input_amount: float,
+        input_mint: Optional[Pubkey] = None,
+        slippage_bps: int = DEFAULT_OPTIONS["SLIPPAGE_BPS"],
+    ):
         from agentipy.tools.trade import TradeManager
+
         try:
-            return await TradeManager.trade(self, output_mint, input_amount, input_mint, slippage_bps)
+            return await TradeManager.trade(
+                self, output_mint, input_amount, input_mint, slippage_bps
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to trade: {e}")
 
     async def lend_assets(self, amount: float):
         from agentipy.tools.use_lulo import LuloManager
+
         try:
             return await LuloManager.lend_asset(self, amount)
         except Exception as e:
             raise AgentKitError(f"Failed to lend asset: {e}")
-    
+
     async def lulo_lend(self, mint_address: Pubkey, amount: float) -> str:
         """
         Lend tokens for yields using Lulo.
@@ -167,11 +235,12 @@ class SolanaAgentKit:
             str: Transaction signature.
         """
         from agentipy.tools.use_lulo import LuloManager
+
         try:
             return await LuloManager.lulo_lend(self, mint_address, amount)
         except Exception as e:
             raise AgentKitError(f"Failed to lend asset: {e}")
-        
+
     async def lulo_withdraw(self, mint_address: Pubkey, amount: float) -> str:
         """
         Withdraw tokens for yields using Lulo.
@@ -185,118 +254,200 @@ class SolanaAgentKit:
             str: Transaction signature.
         """
         from agentipy.tools.use_lulo import LuloManager
+
         try:
             return await LuloManager.lulo_withdraw(self, mint_address, amount)
         except Exception as e:
             raise AgentKitError(f"Failed to withdraw asset: {e}")
-        
+
     async def get_tps(self):
         from agentipy.tools.get_tps import SolanaPerformanceTracker
+
         try:
             return await SolanaPerformanceTracker.fetch_current_tps(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch tps: {e}")
-    
+
     async def get_token_data_by_ticker(self, ticker: str):
         from agentipy.tools.get_token_data import TokenDataManager
+
         try:
             return TokenDataManager.get_token_data_by_ticker(ticker)
         except Exception as e:
             raise AgentKitError(f"Failed to get token data: {e}")
-    
+
     async def get_token_data_by_address(self, mint: str):
         from agentipy.tools.get_token_data import TokenDataManager
-        try: 
+
+        try:
             return TokenDataManager.get_token_data_by_address(Pubkey.from_string(mint))
         except Exception as e:
             raise AgentKitError(f"Failed to get token data: {e}")
 
-    async def launch_pump_fun_token(self, token_name: str, token_ticker: str, description: str, image_url: str, options: Optional[PumpfunTokenOptions] = None):
+    async def launch_pump_fun_token(
+        self,
+        token_name: str,
+        token_ticker: str,
+        description: str,
+        image_url: str,
+        options: Optional[PumpfunTokenOptions] = None,
+    ):
         from agentipy.tools.launch_pumpfun_token import PumpfunTokenManager
+
         try:
-            return await PumpfunTokenManager.launch_pumpfun_token(self, token_name, token_ticker, description, image_url, options)
+            return await PumpfunTokenManager.launch_pumpfun_token(
+                self, token_name, token_ticker, description, image_url, options
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to launch token on pumpfun: {e}")
 
     async def stake(self, amount: int):
         from agentipy.tools.stake_with_jup import StakeManager
+
         try:
             return await StakeManager.stake_with_jup(self, amount)
         except Exception as e:
             raise AgentKitError(f"Failed to stake: {e}")
-    
-    async def create_meteora_dlmm_pool(self, bin_step: int, token_a_mint: Pubkey, token_b_mint: Pubkey, initial_price: float, price_rounding_up: bool, fee_bps: int, activation_type: ActivationType, has_alpha_vault: bool, activation_point: Optional[int]):
+
+    async def create_meteora_dlmm_pool(
+        self,
+        bin_step: int,
+        token_a_mint: Pubkey,
+        token_b_mint: Pubkey,
+        initial_price: float,
+        price_rounding_up: bool,
+        fee_bps: int,
+        activation_type: ActivationType,
+        has_alpha_vault: bool,
+        activation_point: Optional[int],
+    ):
         from agentipy.tools.create_meteora_dlmm_pool import MeteoraManager
+
         try:
-            return await MeteoraManager.create_meteora_dlmm_pool(self, bin_step, token_a_mint, token_b_mint, initial_price, price_rounding_up, fee_bps, activation_type, has_alpha_vault, activation_point)
+            return await MeteoraManager.create_meteora_dlmm_pool(
+                self,
+                bin_step,
+                token_a_mint,
+                token_b_mint,
+                initial_price,
+                price_rounding_up,
+                fee_bps,
+                activation_type,
+                has_alpha_vault,
+                activation_point,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create dlmm pool: {e}")
-    
-    async def buy_with_raydium(self, pair_address: str, sol_in: float = 0.01, slippage: int = 5):
+
+    async def buy_with_raydium(
+        self, pair_address: str, sol_in: float = 0.01, slippage: int = 5
+    ):
         from agentipy.tools.use_raydium import RaydiumManager
+
         try:
-            return await RaydiumManager.buy_with_raydium(self, pair_address, sol_in, slippage)
+            return await RaydiumManager.buy_with_raydium(
+                self, pair_address, sol_in, slippage
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to buy using raydium: {e}")
-    
-    async def sell_with_raydium(self, pair_address: str, percentage: int = 100, slippage: int = 5):
+
+    async def sell_with_raydium(
+        self, pair_address: str, percentage: int = 100, slippage: int = 5
+    ):
         from agentipy.tools.use_raydium import RaydiumManager
+
         try:
-            return await RaydiumManager.sell_with_raydium(self, pair_address, percentage, slippage)
+            return await RaydiumManager.sell_with_raydium(
+                self, pair_address, percentage, slippage
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to sell using raydium: {e}")
-    
+
     async def burn_and_close_accounts(self, token_account: str):
         from agentipy.tools.burn_and_close_account import BurnManager
+
         try:
             return await BurnManager.burn_and_close_account(self, token_account)
         except Exception as e:
             raise AgentKitError(f"Failed to close account: {e}")
-    
+
     async def multiple_burn_and_close_accounts(self, token_accounts: list[str]):
         from agentipy.tools.burn_and_close_account import BurnManager
+
         try:
             return await BurnManager.process_multiple_accounts(self, token_accounts)
         except Exception as e:
             raise AgentKitError(f"Failed to close accounts: {e}")
-    
-    async def create_gibwork_task(self, title: str, content: str, requirements: str, tags: list[str], token_mint_address: Pubkey, token_amount: int):
+
+    async def create_gibwork_task(
+        self,
+        title: str,
+        content: str,
+        requirements: str,
+        tags: list[str],
+        token_mint_address: Pubkey,
+        token_amount: int,
+    ):
         from agentipy.tools.create_gibwork import GibworkManager
+
         try:
-            return await GibworkManager.create_gibwork_task(self, title, content, requirements, tags, token_mint_address, token_amount)
+            return await GibworkManager.create_gibwork_task(
+                self,
+                title,
+                content,
+                requirements,
+                tags,
+                token_mint_address,
+                token_amount,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create task: {e}")
-    
-    async def buy_using_moonshot(self, mint_str: str, collateral_amount: float = 0.01, slippage_bps: int = 500):
+
+    async def buy_using_moonshot(
+        self, mint_str: str, collateral_amount: float = 0.01, slippage_bps: int = 500
+    ):
         from agentipy.tools.use_moonshot import MoonshotManager
+
         try:
-            return await MoonshotManager.buy(self, mint_str, collateral_amount, slippage_bps)
+            return await MoonshotManager.buy(
+                self, mint_str, collateral_amount, slippage_bps
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to buy using moonshot: {e}")
-    
-    async def sell_using_moonshot(self, mint_str: str, token_balance: float = 0.01, slippage_bps: int = 500):
+
+    async def sell_using_moonshot(
+        self, mint_str: str, token_balance: float = 0.01, slippage_bps: int = 500
+    ):
         from agentipy.tools.use_moonshot import MoonshotManager
+
         try:
-            return await MoonshotManager.sell(self, mint_str, token_balance, slippage_bps)
+            return await MoonshotManager.sell(
+                self, mint_str, token_balance, slippage_bps
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to sell using moonshot: {e}")
-    
+
     async def pyth_fetch_price(self, base_token_ticker: str, quote_token_ticker: str):
         from agentipy.tools.use_pyth import PythManager
+
         try:
-            return await PythManager.get_price(self, base_token_ticker, quote_token_ticker)
+            return await PythManager.get_price(
+                self, base_token_ticker, quote_token_ticker
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-    
+
     async def stork_fetch_price(self, asset_id: str):
         from agentipy.tools.use_stork import StorkManager
+
         try:
             return await StorkManager.get_price(self, asset_id)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_balances(self, address: str):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
             return HeliusManager.get_balances(self, address)
         except Exception as e:
@@ -304,161 +455,252 @@ class SolanaAgentKit:
 
     async def get_address_name(self, address: str):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
             return HeliusManager.get_address_name(self, address)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_nft_events(self, accounts: List[str],
-            types: List[str] = None,
-            sources: List[str] = None,
-            start_slot: int = None,
-            end_slot: int = None,
-            start_time: int = None,
-            end_time: int = None,
-            first_verified_creator: List[str] = None,
-            verified_collection_address: List[str] = None,
-            limit : int = None,
-            sort_order: str = None,
-            pagination_token: str = None):
+
+    async def get_nft_events(
+        self,
+        accounts: List[str],
+        types: List[str] = None,
+        sources: List[str] = None,
+        start_slot: int = None,
+        end_slot: int = None,
+        start_time: int = None,
+        end_time: int = None,
+        first_verified_creator: List[str] = None,
+        verified_collection_address: List[str] = None,
+        limit: int = None,
+        sort_order: str = None,
+        pagination_token: str = None,
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_nft_events(self, accounts,types,sources,start_slot,end_slot,start_time,end_time,first_verified_creator,verified_collection_address,limit,sort_order,pagination_token)
+            return HeliusManager.get_nft_events(
+                self,
+                accounts,
+                types,
+                sources,
+                start_slot,
+                end_slot,
+                start_time,
+                end_time,
+                first_verified_creator,
+                verified_collection_address,
+                limit,
+                sort_order,
+                pagination_token,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_mintlists(self, first_verified_creators: List[str],
-        verified_collection_addresses: List[str]=None,
-        limit: int=None,
-        pagination_token: str=None):
+
+    async def get_mintlists(
+        self,
+        first_verified_creators: List[str],
+        verified_collection_addresses: List[str] = None,
+        limit: int = None,
+        pagination_token: str = None,
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_mintlists(self,first_verified_creators,verified_collection_addresses,limit,pagination_token)
+            return HeliusManager.get_mintlists(
+                self,
+                first_verified_creators,
+                verified_collection_addresses,
+                limit,
+                pagination_token,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_nft_fingerprint(self, mints: List[str]):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_nft_fingerprint(self,mints)
+            return HeliusManager.get_nft_fingerprint(self, mints)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_active_listings(self, first_verified_creators: List[str],
-        verified_collection_addresses: List[str]=None,
-        marketplaces: List[str]=None,
-        limit: int=None,
-        pagination_token: str=None):
+
+    async def get_active_listings(
+        self,
+        first_verified_creators: List[str],
+        verified_collection_addresses: List[str] = None,
+        marketplaces: List[str] = None,
+        limit: int = None,
+        pagination_token: str = None,
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_active_listings(self,first_verified_creators,verified_collection_addresses,marketplaces,limit,pagination_token)
+            return HeliusManager.get_active_listings(
+                self,
+                first_verified_creators,
+                verified_collection_addresses,
+                marketplaces,
+                limit,
+                pagination_token,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_nft_metadata(self, mint_accounts: List[str]):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_nft_metadata(self,mint_accounts)
+            return HeliusManager.get_nft_metadata(self, mint_accounts)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_raw_transactions(self,
-        accounts: List[str], 
-        start_slot: int=None,
-        end_slot: int=None,
-        start_time: int=None,
-        end_time: int=None,
-        limit: int=None,
-        sort_order: str=None,
-        pagination_token: str=None):
+
+    async def get_raw_transactions(
+        self,
+        accounts: List[str],
+        start_slot: int = None,
+        end_slot: int = None,
+        start_time: int = None,
+        end_time: int = None,
+        limit: int = None,
+        sort_order: str = None,
+        pagination_token: str = None,
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_raw_transactions(self,accounts,start_slot,end_slot,start_time,end_time,limit,sort_order,pagination_token)
+            return HeliusManager.get_raw_transactions(
+                self,
+                accounts,
+                start_slot,
+                end_slot,
+                start_time,
+                end_time,
+                limit,
+                sort_order,
+                pagination_token,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_parsed_transactions(self, transactions: List[str], commitment: str=None):
+
+    async def get_parsed_transactions(
+        self, transactions: List[str], commitment: str = None
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_parsed_transactions(self,transactions,commitment)
+            return HeliusManager.get_parsed_transactions(self, transactions, commitment)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-    
-    async def get_parsed_transaction_history(self,
-        address: str, 
-        before: str='', 
-        until: str='', 
-        commitment: str='',
-        source: str='',
-        type: str=''):
+
+    async def get_parsed_transaction_history(
+        self,
+        address: str,
+        before: str = "",
+        until: str = "",
+        commitment: str = "",
+        source: str = "",
+        type: str = "",
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_parsed_transaction_history(self,address,before,until,commitment,source,type)
+            return HeliusManager.get_parsed_transaction_history(
+                self, address, before, until, commitment, source, type
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def create_webhook(self, 
-        webhook_url: str, 
-        transaction_types: list, 
-        account_addresses: list, 
-        webhook_type: str, 
-        txn_status: str="all",
-        auth_header: str=None):
+
+    async def create_webhook(
+        self,
+        webhook_url: str,
+        transaction_types: list,
+        account_addresses: list,
+        webhook_type: str,
+        txn_status: str = "all",
+        auth_header: str = None,
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.create_webhook(self,webhook_url,transaction_types,account_addresses,webhook_type,txn_status,auth_header)
+            return HeliusManager.create_webhook(
+                self,
+                webhook_url,
+                transaction_types,
+                account_addresses,
+                webhook_type,
+                txn_status,
+                auth_header,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_all_webhooks(self):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
             return HeliusManager.get_all_webhooks(self)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_webhook(self, webhook_id: str):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.get_webhook(self,webhook_id)
+            return HeliusManager.get_webhook(self, webhook_id)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def edit_webhook(self,
-        webhook_id: str, 
-        webhook_url: str, 
-        transaction_types: list, 
-        account_addresses: list, 
-        webhook_type: str, 
-        txn_status: str="all",
-        auth_header: str=None):
+
+    async def edit_webhook(
+        self,
+        webhook_id: str,
+        webhook_url: str,
+        transaction_types: list,
+        account_addresses: list,
+        webhook_type: str,
+        txn_status: str = "all",
+        auth_header: str = None,
+    ):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.edit_webhook(self,webhook_id,webhook_url,transaction_types,account_addresses,webhook_type,txn_status,auth_header)
+            return HeliusManager.edit_webhook(
+                self,
+                webhook_id,
+                webhook_url,
+                transaction_types,
+                account_addresses,
+                webhook_type,
+                txn_status,
+                auth_header,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
 
     async def delete_webhook(self, webhook_id: str):
         from agentipy.tools.use_helius import HeliusManager
+
         try:
-            return HeliusManager.delete_webhook(self,webhook_id)
+            return HeliusManager.delete_webhook(self, webhook_id)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def fetch_token_report_summary(mint:str):
+
+    async def fetch_token_report_summary(mint: str):
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_token_report_summary(mint)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def fetch_token_detailed_report(mint:str):
+
+    async def fetch_token_detailed_report(mint: str):
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_token_detailed_report(mint)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-    
+
     async def fetch_all_domains(page: int = 1, limit: int = 50, verified: bool = False):
         """
         Fetches all registered domains with optional pagination and filtering.
@@ -475,11 +717,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_all_domains(page, limit, verified)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch all domains: {e}")
-    
+
     async def fetch_domains_csv(verified: bool = False):
         """
         Fetches all registered domains in CSV format.
@@ -494,11 +737,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_domains_csv(verified)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch domains CSV: {e}")
-        
+
     async def lookup_domain(domain: str):
         """
         Looks up a domain by name.
@@ -513,12 +757,13 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.lookup_domain(domain)
         except Exception as e:
             raise AgentKitError(f"Failed to lookup domain: {e}")
-        
-    async def fetch_domain_records(domain: str) :
+
+    async def fetch_domain_records(domain: str):
         """
         Fetches all records for a domain.
 
@@ -532,11 +777,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_domain_records(domain)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch domain records: {e}")
-        
+
     async def fetch_leaderboard():
         """
         Fetches the leaderboard with optional pagination.
@@ -552,11 +798,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_leaderboard()
         except Exception as e:
             raise AgentKitError(f"Failed to fetch leaderboard: {e}")
-        
+
     async def fetch_new_tokens():
         """
         Fetches new tokens with optional pagination.
@@ -572,11 +819,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_new_tokens()
         except Exception as e:
             raise AgentKitError(f"Failed to fetch new tokens: {e}")
-        
+
     async def fetch_most_viewed_tokens():
         """
         Fetches the most viewed tokens with optional pagination.
@@ -592,11 +840,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_most_viewed_tokens()
         except Exception as e:
             raise AgentKitError(f"Failed to fetch most viewed tokens: {e}")
-        
+
     async def fetch_trending_tokens():
         """
         Fetches trending tokens with optional pagination.
@@ -612,6 +861,7 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_trending_tokens()
         except Exception as e:
@@ -632,6 +882,7 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_recently_verified_tokens()
         except Exception as e:
@@ -652,6 +903,7 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_token_lp_lockers(token_id)
         except Exception as e:
@@ -672,11 +924,12 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_token_flux_lp_lockers(token_id)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch token flux LP lockers: {e}")
-        
+
     async def fetch_token_votes(mint: str):
         """
         Fetches token votes with optional pagination.
@@ -692,163 +945,287 @@ class SolanaAgentKit:
             Exception: If the API call fails.
         """
         from agentipy.tools.rugcheck import RugCheckManager
+
         try:
             return await RugCheckManager.fetch_token_votes(mint)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch token votes: {e}")
-    
-    async def get_pump_curve_state(conn: AsyncClient, curve_address: Pubkey,):
+
+    async def get_pump_curve_state(
+        conn: AsyncClient,
+        curve_address: Pubkey,
+    ):
         from agentipy.tools.use_pumpfun import PumpfunManager
+
         try:
             return PumpfunManager.get_pump_curve_state(conn, curve_address)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def calculate_pump_curve_price(curve_state:BondingCurveState):
+
+    async def calculate_pump_curve_price(curve_state: BondingCurveState):
         from agentipy.tools.use_pumpfun import PumpfunManager
+
         try:
             return PumpfunManager.calculate_pump_curve_price(curve_state)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def buy_token(self, mint:Pubkey, bonding_curve:Pubkey,associated_bonding_curve:Pubkey, amount:float, slippage:float,max_retries:int):
+
+    async def buy_token(
+        self,
+        mint: Pubkey,
+        bonding_curve: Pubkey,
+        associated_bonding_curve: Pubkey,
+        amount: float,
+        slippage: float,
+        max_retries: int,
+    ):
         from agentipy.tools.use_pumpfun import PumpfunManager
+
         try:
-            return PumpfunManager.buy_token(self,mint,bonding_curve,associated_bonding_curve,amount,slippage,max_retries)
+            return PumpfunManager.buy_token(
+                self,
+                mint,
+                bonding_curve,
+                associated_bonding_curve,
+                amount,
+                slippage,
+                max_retries,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
 
-    async def sell_token(self, mint:Pubkey, bonding_curve:Pubkey,associated_bonding_curve:Pubkey, amount:float, slippage:float,max_retries:int):
+    async def sell_token(
+        self,
+        mint: Pubkey,
+        bonding_curve: Pubkey,
+        associated_bonding_curve: Pubkey,
+        amount: float,
+        slippage: float,
+        max_retries: int,
+    ):
         from agentipy.tools.use_pumpfun import PumpfunManager
+
         try:
-            return PumpfunManager.sell_token(self, mint, bonding_curve, associated_bonding_curve, slippage, max_retries)
+            return PumpfunManager.sell_token(
+                self,
+                mint,
+                bonding_curve,
+                associated_bonding_curve,
+                slippage,
+                max_retries,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
 
     async def resolve_name_to_address(self, domain: str):
         from agentipy.tools.use_sns import NameServiceManager
+
         try:
             return NameServiceManager.resolve_name_to_address(self, domain)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_favourite_domain(self, owner: str):
         from agentipy.tools.use_sns import NameServiceManager
+
         try:
             return NameServiceManager.get_favourite_domain(self, owner)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_all_domains_for_owner(self, owner: str):
         from agentipy.tools.use_sns import NameServiceManager
+
         try:
             return NameServiceManager.get_all_domains_for_owner(self, owner)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_registration_transaction(self, domain: str, buyer: str, buyer_token_account: str, space: int, 
-                                     mint: Optional[str] = None, referrer_key: Optional[str] = None):
+
+    async def get_registration_transaction(
+        self,
+        domain: str,
+        buyer: str,
+        buyer_token_account: str,
+        space: int,
+        mint: Optional[str] = None,
+        referrer_key: Optional[str] = None,
+    ):
         from agentipy.tools.use_sns import NameServiceManager
+
         try:
-            return NameServiceManager.get_registration_transaction(self, domain, buyer, buyer_token_account, space, mint, referrer_key)
+            return NameServiceManager.get_registration_transaction(
+                self, domain, buyer, buyer_token_account, space, mint, referrer_key
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
 
-    async def deploy_collection(self, name: str, uri: str, royalty_basis_points: int, creator_address: str):
+    async def deploy_collection(
+        self, name: str, uri: str, royalty_basis_points: int, creator_address: str
+    ):
         from agentipy.tools.use_metaplex import DeployCollectionManager
+
         try:
-            return DeployCollectionManager.deploy_collection(self, name, uri, royalty_basis_points, creator_address)
+            return DeployCollectionManager.deploy_collection(
+                self, name, uri, royalty_basis_points, creator_address
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_metaplex_asset(self, assetId:str):
+
+    async def get_metaplex_asset(self, assetId: str):
         from agentipy.tools.use_metaplex import DeployCollectionManager
+
         try:
             return DeployCollectionManager.get_metaplex_asset(self, assetId)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_metaplex_assets_by_creator(self,creator: str, onlyVerified: bool = False, sortBy: Union[str, None] = None,
-    sortDirection: Union[str, None] = None,
-    limit: Union[int, None] = None,
-    page: Union[int, None] = None,
-    before: Union[str, None] = None,
-    after: Union[str, None] = None):
+
+    async def get_metaplex_assets_by_creator(
+        self,
+        creator: str,
+        onlyVerified: bool = False,
+        sortBy: Union[str, None] = None,
+        sortDirection: Union[str, None] = None,
+        limit: Union[int, None] = None,
+        page: Union[int, None] = None,
+        before: Union[str, None] = None,
+        after: Union[str, None] = None,
+    ):
         from agentipy.tools.use_metaplex import DeployCollectionManager
+
         try:
-            return DeployCollectionManager.get_metaplex_assets_by_creator(self, creator, onlyVerified, sortBy, sortDirection, limit, page, before, after)
+            return DeployCollectionManager.get_metaplex_assets_by_creator(
+                self,
+                creator,
+                onlyVerified,
+                sortBy,
+                sortDirection,
+                limit,
+                page,
+                before,
+                after,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def get_metaplex_assets_by_authority(self,authority: str, sortBy: Union[str, None] = None,
-    sortDirection: Union[str, None] = None,
-    limit: Union[int, None] = None,
-    page: Union[int, None] = None,
-    before: Union[str, None] = None,
-    after: Union[str, None] = None):
+
+    async def get_metaplex_assets_by_authority(
+        self,
+        authority: str,
+        sortBy: Union[str, None] = None,
+        sortDirection: Union[str, None] = None,
+        limit: Union[int, None] = None,
+        page: Union[int, None] = None,
+        before: Union[str, None] = None,
+        after: Union[str, None] = None,
+    ):
         from agentipy.tools.use_metaplex import DeployCollectionManager
+
         try:
-            return DeployCollectionManager.get_metaplex_assets_by_authority(self, authority, sortBy, sortDirection, limit, page, before, after)
+            return DeployCollectionManager.get_metaplex_assets_by_authority(
+                self, authority, sortBy, sortDirection, limit, page, before, after
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
-    async def mint_metaplex_core_nft(self,collectionMint: str, name: str, uri: str, sellerFeeBasisPoints: Union[int, None] = None, address: Union[str, None] = None,
-    share: Union[str, None] = None, recipient: Union[str, None] = None):
+
+    async def mint_metaplex_core_nft(
+        self,
+        collectionMint: str,
+        name: str,
+        uri: str,
+        sellerFeeBasisPoints: Union[int, None] = None,
+        address: Union[str, None] = None,
+        share: Union[str, None] = None,
+        recipient: Union[str, None] = None,
+    ):
         from agentipy.tools.use_metaplex import DeployCollectionManager
+
         try:
-            return DeployCollectionManager.mint_metaplex_core_nft(self, collectionMint, name, uri, sellerFeeBasisPoints, address, share, recipient)
+            return DeployCollectionManager.mint_metaplex_core_nft(
+                self,
+                collectionMint,
+                name,
+                uri,
+                sellerFeeBasisPoints,
+                address,
+                share,
+                recipient,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def create_debridge_transaction(
-    self,
-    src_chain_id: str,
-    src_chain_token_in: str,
-    src_chain_token_in_amount: str,
-    dst_chain_id: str,
-    dst_chain_token_out: str,
-    dst_chain_token_out_recipient: str,
-    src_chain_order_authority_address: str,
-    dst_chain_order_authority_address: str,
-    affiliate_fee_percent: str = "0",
-    affiliate_fee_recipient: str = "",
-    prepend_operating_expenses: bool = True,
-    dst_chain_token_out_amount: str = "auto"):
-        from agentipy.tools.use_debridge import DeBridgeManager   
+        self,
+        src_chain_id: str,
+        src_chain_token_in: str,
+        src_chain_token_in_amount: str,
+        dst_chain_id: str,
+        dst_chain_token_out: str,
+        dst_chain_token_out_recipient: str,
+        src_chain_order_authority_address: str,
+        dst_chain_order_authority_address: str,
+        affiliate_fee_percent: str = "0",
+        affiliate_fee_recipient: str = "",
+        prepend_operating_expenses: bool = True,
+        dst_chain_token_out_amount: str = "auto",
+    ):
+        from agentipy.tools.use_debridge import DeBridgeManager
+
         try:
-            return DeBridgeManager.create_debridge_transaction(self, src_chain_id, src_chain_token_in, src_chain_token_in_amount, dst_chain_id, dst_chain_token_out, dst_chain_token_out_recipient, src_chain_order_authority_address, dst_chain_order_authority_address, affiliate_fee_percent, affiliate_fee_recipient, prepend_operating_expenses, dst_chain_token_out_amount)
+            return DeBridgeManager.create_debridge_transaction(
+                self,
+                src_chain_id,
+                src_chain_token_in,
+                src_chain_token_in_amount,
+                dst_chain_id,
+                dst_chain_token_out,
+                dst_chain_token_out_recipient,
+                src_chain_order_authority_address,
+                dst_chain_order_authority_address,
+                affiliate_fee_percent,
+                affiliate_fee_recipient,
+                prepend_operating_expenses,
+                dst_chain_token_out_amount,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def execute_debridge_transaction(self, transaction_data: dict):
-        from agentipy.tools.use_debridge import DeBridgeManager   
+        from agentipy.tools.use_debridge import DeBridgeManager
+
         try:
-            return await DeBridgeManager.execute_debridge_transaction(self, transaction_data)
+            return await DeBridgeManager.execute_debridge_transaction(
+                self, transaction_data
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def check_transaction_status(self, tx_hash: str):
-        from agentipy.tools.use_debridge import DeBridgeManager   
+        from agentipy.tools.use_debridge import DeBridgeManager
+
         try:
             return await DeBridgeManager.check_transaction_status(self, tx_hash)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def cybers_create_coin(
-        self, 
+        self,
         name: str,
         symbol: str,
         image_path: str,
         tweet_author_id: str,
-        tweet_author_username: str):
-        from agentipy.tools.use_cybers import CybersManager   
+        tweet_author_username: str,
+    ):
+        from agentipy.tools.use_cybers import CybersManager
+
         try:
-            return CybersManager.create_coin(self, name, symbol, image_path, tweet_author_id, tweet_author_username)
+            return CybersManager.create_coin(
+                self, name, symbol, image_path, tweet_author_id, tweet_author_username
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
 
     async def get_tip_accounts(self):
         from agentipy.tools.use_jito import JitoManager
+
         try:
             return JitoManager.get_tip_accounts(self)
         except Exception as e:
@@ -856,13 +1233,15 @@ class SolanaAgentKit:
 
     async def get_random_tip_account():
         from agentipy.tools.use_jito import JitoManager
+
         try:
             return JitoManager.get_random_tip_account()
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_bundle_statuses(self, bundle_uuids):
         from agentipy.tools.use_jito import JitoManager
+
         try:
             return JitoManager.get_bundle_statuses(self, bundle_uuids)
         except Exception as e:
@@ -870,240 +1249,250 @@ class SolanaAgentKit:
 
     async def send_bundle(self, params=None):
         from agentipy.tools.use_jito import JitoManager
+
         try:
             return JitoManager.send_bundle(self, params)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def get_inflight_bundle_statuses(self, bundle_uuids):
         from agentipy.tools.use_jito import JitoManager
+
         try:
             return JitoManager.get_inflight_bundle_statuses(self, bundle_uuids)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-        
+
     async def send_txn(self, params=None, bundleOnly=False):
         from agentipy.tools.use_jito import JitoManager
+
         try:
             return JitoManager.send_txn(self, params, bundleOnly)
         except Exception as e:
             raise AgentKitError(f"Failed to {e}")
-    
+
     async def get_account_balances(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_account_balances(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch account balances: {e}")
 
-
-    async def request_withdrawal(self, address: str, blockchain: str, quantity: str, symbol: str, **kwargs):
+    async def request_withdrawal(
+        self, address: str, blockchain: str, quantity: str, symbol: str, **kwargs
+    ):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
-            return await BackpackManager.request_withdrawal(self, address, blockchain, quantity, symbol, **kwargs)
+            return await BackpackManager.request_withdrawal(
+                self, address, blockchain, quantity, symbol, **kwargs
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to request withdrawal: {e}")
 
-
     async def get_account_settings(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_account_settings(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch account settings: {e}")
 
-
     async def update_account_settings(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.update_account_settings(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to update account settings: {e}")
 
-
     async def get_borrow_lend_positions(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_borrow_lend_positions(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch borrow/lend positions: {e}")
 
-
     async def execute_borrow_lend(self, quantity: str, side: str, symbol: str):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
-            return await BackpackManager.execute_borrow_lend(self, quantity, side, symbol)
+            return await BackpackManager.execute_borrow_lend(
+                self, quantity, side, symbol
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to execute borrow/lend operation: {e}")
 
-
     async def get_collateral_info(self, sub_account_id: int = None):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_collateral_info(self, sub_account_id)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch collateral information: {e}")
 
-
     async def get_account_deposits(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_account_deposits(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch account deposits: {e}")
 
-
     async def get_open_positions(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_open_positions(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch open positions: {e}")
 
-
     async def get_borrow_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_borrow_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch borrow history: {e}")
 
-
     async def get_interest_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_interest_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch interest history: {e}")
 
-
     async def get_fill_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_fill_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch fill history: {e}")
 
-
     async def get_borrow_position_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_borrow_position_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch borrow position history: {e}")
 
-
     async def get_funding_payments(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_funding_payments(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch funding payments: {e}")
 
-
     async def get_order_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_order_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch order history: {e}")
 
-
     async def get_pnl_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_pnl_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch PNL history: {e}")
 
-
     async def get_settlement_history(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_settlement_history(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch settlement history: {e}")
 
-
     async def get_users_open_orders(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_users_open_orders(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch user's open orders: {e}")
 
-
     async def execute_order(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.execute_order(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to execute order: {e}")
 
-
     async def cancel_open_order(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.cancel_open_order(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to cancel open order: {e}")
 
-
     async def get_open_orders(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_open_orders(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch open orders: {e}")
 
-
     async def cancel_open_orders(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.cancel_open_orders(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to cancel open orders: {e}")
 
-
     async def get_supported_assets(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_supported_assets(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch supported assets: {e}")
 
-
     async def get_ticker_information(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_ticker_information(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch ticker information: {e}")
 
-
     async def get_markets(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_markets(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch markets: {e}")
 
-
     async def get_market(self, **kwargs):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_market(self, **kwargs)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch market: {e}")
 
-
     async def get_tickers(self):
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_tickers(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch tickers: {e}")
-    
+
     async def get_depth(self, symbol: str):
         """
         Retrieves the order book depth for a given market symbol.
@@ -1115,13 +1504,15 @@ class SolanaAgentKit:
             dict: Order book depth.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_depth(self, symbol)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch order book depth: {e}")
 
-
-    async def get_klines(self, symbol: str, interval: str, start_time: int, end_time: int = None):
+    async def get_klines(
+        self, symbol: str, interval: str, start_time: int, end_time: int = None
+    ):
         """
         Get K-Lines for the given market symbol.
 
@@ -1135,11 +1526,13 @@ class SolanaAgentKit:
             dict: K-Lines data.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
-            return await BackpackManager.get_klines(self, symbol, interval, start_time, end_time)
+            return await BackpackManager.get_klines(
+                self, symbol, interval, start_time, end_time
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to fetch K-Lines: {e}")
-
 
     async def get_mark_price(self, symbol: str):
         """
@@ -1152,11 +1545,11 @@ class SolanaAgentKit:
             dict: Mark price data.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_mark_price(self, symbol)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch mark price: {e}")
-
 
     async def get_open_interest(self, symbol: str):
         """
@@ -1169,13 +1562,15 @@ class SolanaAgentKit:
             dict: Open interest data.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_open_interest(self, symbol)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch open interest: {e}")
 
-
-    async def get_funding_interval_rates(self, symbol: str, limit: int = 100, offset: int = 0):
+    async def get_funding_interval_rates(
+        self, symbol: str, limit: int = 100, offset: int = 0
+    ):
         """
         Funding interval rate history for futures.
 
@@ -1188,11 +1583,13 @@ class SolanaAgentKit:
             dict: Funding interval rate data.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
-            return await BackpackManager.get_funding_interval_rates(self, symbol, limit, offset)
+            return await BackpackManager.get_funding_interval_rates(
+                self, symbol, limit, offset
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to fetch funding interval rates: {e}")
-
 
     async def get_status(self):
         """
@@ -1202,11 +1599,11 @@ class SolanaAgentKit:
             dict: System status.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_status(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch system status: {e}")
-
 
     async def send_ping(self):
         """
@@ -1216,11 +1613,11 @@ class SolanaAgentKit:
             str: "pong"
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.send_ping(self)
         except Exception as e:
             raise AgentKitError(f"Failed to send ping: {e}")
-
 
     async def get_system_time(self):
         """
@@ -1230,11 +1627,11 @@ class SolanaAgentKit:
             str: Current system time.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_system_time(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch system time: {e}")
-
 
     async def get_recent_trades(self, symbol: str, limit: int = 100):
         """
@@ -1248,13 +1645,15 @@ class SolanaAgentKit:
             dict: Recent trade data.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
             return await BackpackManager.get_recent_trades(self, symbol, limit)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch recent trades: {e}")
 
-
-    async def get_historical_trades(self, symbol: str, limit: int = 100, offset: int = 0):
+    async def get_historical_trades(
+        self, symbol: str, limit: int = 100, offset: int = 0
+    ):
         """
         Retrieves all historical trades for the given symbol.
 
@@ -1267,12 +1666,17 @@ class SolanaAgentKit:
             dict: Historical trade data.
         """
         from agentipy.tools.use_backpack import BackpackManager
+
         try:
-            return await BackpackManager.get_historical_trades(self, symbol, limit, offset)
+            return await BackpackManager.get_historical_trades(
+                self, symbol, limit, offset
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to fetch historical trades: {e}")
-    
-    async def close_perp_trade_short(self, price: float, trade_mint: str) -> Optional[Dict[str, Any]]:
+
+    async def close_perp_trade_short(
+        self, price: float, trade_mint: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Closes a perpetual short trade.
 
@@ -1285,11 +1689,16 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_adrena import AdrenaTradeManager
-            return await AdrenaTradeManager.close_perp_trade_short(self, price, trade_mint)
+
+            return await AdrenaTradeManager.close_perp_trade_short(
+                self, price, trade_mint
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to close perp short trade: {e}")
 
-    async def close_perp_trade_long(self, price: float, trade_mint: str) -> Optional[Dict[str, Any]]:
+    async def close_perp_trade_long(
+        self, price: float, trade_mint: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Closes a perpetual long trade.
 
@@ -1302,7 +1711,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_adrena import AdrenaTradeManager
-            return await AdrenaTradeManager.close_perp_trade_long(self, price, trade_mint)
+
+            return await AdrenaTradeManager.close_perp_trade_long(
+                self, price, trade_mint
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to close perp long trade: {e}")
 
@@ -1331,8 +1743,15 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_adrena import AdrenaTradeManager
+
             return await AdrenaTradeManager.open_perp_trade_long(
-                self, price, collateral_amount, collateral_mint, leverage, trade_mint, slippage
+                self,
+                price,
+                collateral_amount,
+                collateral_mint,
+                leverage,
+                trade_mint,
+                slippage,
             )
         except Exception as e:
             raise AgentKitError(f"Failed to open perp long trade: {e}")
@@ -1362,8 +1781,15 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_adrena import AdrenaTradeManager
+
             return await AdrenaTradeManager.open_perp_trade_short(
-                self, price, collateral_amount, collateral_mint, leverage, trade_mint, slippage
+                self,
+                price,
+                collateral_amount,
+                collateral_mint,
+                leverage,
+                trade_mint,
+                slippage,
             )
         except Exception as e:
             raise AgentKitError(f"Failed to open perp short trade: {e}")
@@ -1392,9 +1818,16 @@ class SolanaAgentKit:
             dict: Transaction details.
         """
         from agentipy.tools.use_3land import ThreeLandManager
+
         try:
             return await ThreeLandManager.create_3land_collection(
-                self, collection_symbol, collection_name, collection_description, main_image_url, cover_image_url, is_devnet
+                self,
+                collection_symbol,
+                collection_name,
+                collection_description,
+                main_image_url,
+                cover_image_url,
+                is_devnet,
             )
         except Exception as e:
             raise AgentKitError(f"Failed to create 3land collection: {e}")
@@ -1438,6 +1871,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_3land import ThreeLandManager
+
             return await ThreeLandManager.create_3land_nft(
                 self,
                 item_name,
@@ -1457,7 +1891,9 @@ class SolanaAgentKit:
         except Exception as e:
             raise AgentKitError(f"Failed to create 3land NFT: {e}")
 
-    async def create_drift_user_account(self, deposit_amount: float, deposit_symbol: str) -> Optional[Dict[str, Any]]:
+    async def create_drift_user_account(
+        self, deposit_amount: float, deposit_symbol: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Creates a Drift user account with an initial deposit.
 
@@ -1470,7 +1906,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.create_drift_user_account(self, deposit_amount, deposit_symbol)
+
+            return await DriftManager.create_drift_user_account(
+                self, deposit_amount, deposit_symbol
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create Drift user account: {e}")
 
@@ -1490,7 +1929,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.deposit_to_drift_user_account(self, amount, symbol, is_repayment)
+
+            return await DriftManager.deposit_to_drift_user_account(
+                self, amount, symbol, is_repayment
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to deposit to Drift user account: {e}")
 
@@ -1510,12 +1952,20 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.withdraw_from_drift_user_account(self, amount, symbol, is_borrow)
+
+            return await DriftManager.withdraw_from_drift_user_account(
+                self, amount, symbol, is_borrow
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to withdraw from Drift user account: {e}")
 
     async def trade_using_drift_perp_account(
-        self, amount: float, symbol: str, action: str, trade_type: str, price: Optional[float] = None
+        self,
+        amount: float,
+        symbol: str,
+        action: str,
+        trade_type: str,
+        price: Optional[float] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Executes a trade using a Drift perpetual account.
@@ -1532,7 +1982,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.trade_using_drift_perp_account(self, amount, symbol, action, trade_type, price)
+
+            return await DriftManager.trade_using_drift_perp_account(
+                self, amount, symbol, action, trade_type, price
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to trade using Drift perp account: {e}")
 
@@ -1545,6 +1998,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.check_if_drift_account_exists(self)
         except Exception as e:
             raise AgentKitError(f"Failed to check Drift account existence: {e}")
@@ -1558,10 +2012,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.drift_user_account_info(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch Drift user account info: {e}")
-        
+
     async def get_available_drift_markets(self) -> Optional[Dict[str, Any]]:
         """
         Retrieves available markets on Drift.
@@ -1571,11 +2026,14 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.get_available_drift_markets(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch available Drift markets: {e}")
 
-    async def stake_to_drift_insurance_fund(self, amount: float, symbol: str) -> Optional[Dict[str, Any]]:
+    async def stake_to_drift_insurance_fund(
+        self, amount: float, symbol: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Stakes funds into the Drift insurance fund.
 
@@ -1588,11 +2046,16 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.stake_to_drift_insurance_fund(self, amount, symbol)
+
+            return await DriftManager.stake_to_drift_insurance_fund(
+                self, amount, symbol
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to stake to Drift insurance fund: {e}")
 
-    async def request_unstake_from_drift_insurance_fund(self, amount: float, symbol: str) -> Optional[Dict[str, Any]]:
+    async def request_unstake_from_drift_insurance_fund(
+        self, amount: float, symbol: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Requests unstaking from the Drift insurance fund.
 
@@ -1605,11 +2068,18 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.request_unstake_from_drift_insurance_fund(self, amount, symbol)
-        except Exception as e:
-            raise AgentKitError(f"Failed to request unstake from Drift insurance fund: {e}")
 
-    async def unstake_from_drift_insurance_fund(self, symbol: str) -> Optional[Dict[str, Any]]:
+            return await DriftManager.request_unstake_from_drift_insurance_fund(
+                self, amount, symbol
+            )
+        except Exception as e:
+            raise AgentKitError(
+                f"Failed to request unstake from Drift insurance fund: {e}"
+            )
+
+    async def unstake_from_drift_insurance_fund(
+        self, symbol: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Completes an unstaking request from the Drift insurance fund.
 
@@ -1621,6 +2091,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.unstake_from_drift_insurance_fund(self, symbol)
         except Exception as e:
             raise AgentKitError(f"Failed to unstake from Drift insurance fund: {e}")
@@ -1648,11 +2119,16 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.drift_swap_spot_token(self, from_symbol, to_symbol, slippage, to_amount, from_amount)
+
+            return await DriftManager.drift_swap_spot_token(
+                self, from_symbol, to_symbol, slippage, to_amount, from_amount
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to swap spot token on Drift: {e}")
 
-    async def get_drift_perp_market_funding_rate(self, symbol: str, period: str = "year") -> Optional[Dict[str, Any]]:
+    async def get_drift_perp_market_funding_rate(
+        self, symbol: str, period: str = "year"
+    ) -> Optional[Dict[str, Any]]:
         """
         Retrieves the funding rate for a Drift perpetual market.
 
@@ -1665,11 +2141,16 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.get_drift_perp_market_funding_rate(self, symbol, period)
+
+            return await DriftManager.get_drift_perp_market_funding_rate(
+                self, symbol, period
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to get Drift perp market funding rate: {e}")
-        
-    async def get_drift_entry_quote_of_perp_trade(self, amount: float, symbol: str, action: str) -> Optional[Dict[str, Any]]:
+
+    async def get_drift_entry_quote_of_perp_trade(
+        self, amount: float, symbol: str, action: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Retrieves the entry quote for a perpetual trade on Drift.
 
@@ -1683,7 +2164,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.get_drift_entry_quote_of_perp_trade(self, amount, symbol, action)
+
+            return await DriftManager.get_drift_entry_quote_of_perp_trade(
+                self, amount, symbol, action
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to get Drift entry quote of perp trade: {e}")
 
@@ -1699,6 +2183,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.get_drift_lend_borrow_apy(self, symbol)
         except Exception as e:
             raise AgentKitError(f"Failed to get Drift lend/borrow APY: {e}")
@@ -1734,13 +2219,25 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.create_drift_vault(
-                self, name, market_name, redeem_period, max_tokens, min_deposit_amount, management_fee, profit_share, hurdle_rate, permissioned
+                self,
+                name,
+                market_name,
+                redeem_period,
+                max_tokens,
+                min_deposit_amount,
+                management_fee,
+                profit_share,
+                hurdle_rate,
+                permissioned,
             )
         except Exception as e:
             raise AgentKitError(f"Failed to create Drift vault: {e}")
 
-    async def update_drift_vault_delegate(self, vault: str, delegate_address: str) -> Optional[Dict[str, Any]]:
+    async def update_drift_vault_delegate(
+        self, vault: str, delegate_address: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Updates the delegate address for a Drift vault.
 
@@ -1753,7 +2250,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.update_drift_vault_delegate(self, vault, delegate_address)
+
+            return await DriftManager.update_drift_vault_delegate(
+                self, vault, delegate_address
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to update Drift vault delegate: {e}")
 
@@ -1790,8 +2290,19 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.update_drift_vault(
-                self, vault_address, name, market_name, redeem_period, max_tokens, min_deposit_amount, management_fee, profit_share, hurdle_rate, permissioned
+                self,
+                vault_address,
+                name,
+                market_name,
+                redeem_period,
+                max_tokens,
+                min_deposit_amount,
+                management_fee,
+                profit_share,
+                hurdle_rate,
+                permissioned,
             )
         except Exception as e:
             raise AgentKitError(f"Failed to update Drift vault: {e}")
@@ -1808,11 +2319,14 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.get_drift_vault_info(self, vault_name)
         except Exception as e:
             raise AgentKitError(f"Failed to get Drift vault info: {e}")
-        
-    async def deposit_into_drift_vault(self, amount: float, vault: str) -> Optional[Dict[str, Any]]:
+
+    async def deposit_into_drift_vault(
+        self, amount: float, vault: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Deposits funds into a Drift vault.
 
@@ -1825,11 +2339,14 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.deposit_into_drift_vault(self, amount, vault)
         except Exception as e:
             raise AgentKitError(f"Failed to deposit into Drift vault: {e}")
 
-    async def request_withdrawal_from_drift_vault(self, amount: float, vault: str) -> Optional[Dict[str, Any]]:
+    async def request_withdrawal_from_drift_vault(
+        self, amount: float, vault: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Requests a withdrawal from a Drift vault.
 
@@ -1842,7 +2359,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.request_withdrawal_from_drift_vault(self, amount, vault)
+
+            return await DriftManager.request_withdrawal_from_drift_vault(
+                self, amount, vault
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to request withdrawal from Drift vault: {e}")
 
@@ -1858,6 +2378,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.withdraw_from_drift_vault(self, vault)
         except Exception as e:
             raise AgentKitError(f"Failed to withdraw from Drift vault: {e}")
@@ -1874,6 +2395,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
+
             return await DriftManager.derive_drift_vault_address(self, name)
         except Exception as e:
             raise AgentKitError(f"Failed to derive Drift vault address: {e}")
@@ -1903,7 +2425,10 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_drift import DriftManager
-            return await DriftManager.trade_using_delegated_drift_vault(self, vault, amount, symbol, action, trade_type, price)
+
+            return await DriftManager.trade_using_delegated_drift_vault(
+                self, vault, amount, symbol, action, trade_type, price
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to trade using delegated Drift vault: {e}")
 
@@ -1924,11 +2449,16 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_flash import FlashTradeManager
-            return await FlashTradeManager.flash_open_trade(self, token, side, collateral_usd, leverage)
+
+            return await FlashTradeManager.flash_open_trade(
+                self, token, side, collateral_usd, leverage
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to open flash trade: {e}")
 
-    async def flash_close_trade(self, token: str, side: str) -> Optional[Dict[str, Any]]:
+    async def flash_close_trade(
+        self, token: str, side: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Closes a flash trade using the agent toolkit API.
 
@@ -1941,10 +2471,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_flash import FlashTradeManager
+
             return await FlashTradeManager.flash_close_trade(self, token, side)
         except Exception as e:
             raise AgentKitError(f"Failed to close flash trade: {e}")
-        
+
     async def resolve_all_domains(self, domain: str) -> Optional[str]:
         """
         Resolves all domain types for a given domain.
@@ -1957,6 +2488,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_alldomains import AllDomainsManager
+
             return await AllDomainsManager.resolve_all_domains(self, domain)
         except Exception as e:
             raise AgentKitError(f"Failed to resolve all domains: {e}")
@@ -1973,6 +2505,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_alldomains import AllDomainsManager
+
             return await AllDomainsManager.get_owned_domains_for_tld(self, tld)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch owned domains: {e}")
@@ -1986,6 +2519,7 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_alldomains import AllDomainsManager
+
             return await AllDomainsManager.get_all_domains_tlds(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch all domains TLDs: {e}")
@@ -2002,164 +2536,211 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_alldomains import AllDomainsManager
+
             return await AllDomainsManager.get_owned_all_domains(self, owner)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch owned all domains: {e}")
-        
+
     async def send_compressed_airdrop(
-        self, 
+        self,
         mint_address: str,
         amount: float,
         decimals: int,
         recipients: List[str],
         priority_fee_in_lamports: int,
-        should_log: Optional[bool] = False,) -> Optional[List[str]]:
+        should_log: Optional[bool] = False,
+    ) -> Optional[List[str]]:
         try:
             from agentipy.tools.use_lightprotocol import LightProtocolManager
-            return await LightProtocolManager.send_compressed_airdrop(self, mint_address, amount, decimals, recipients, priority_fee_in_lamports, should_log)
+
+            return await LightProtocolManager.send_compressed_airdrop(
+                self,
+                mint_address,
+                amount,
+                decimals,
+                recipients,
+                priority_fee_in_lamports,
+                should_log,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to fetch owned all domains: {e}")
-        
+
     async def create_manifest_market(
-        self, 
+        self,
         base_mint: str,
         quote_mint: str,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_manifest import ManifestManager
+
             return await ManifestManager.create_market(self, base_mint, quote_mint)
         except Exception as e:
             raise AgentKitError(f"Failed to create manifest market: {e}")
-        
+
     async def place_limit_order(
-        self, 
+        self,
         market_id: str,
         quantity: float,
         side: str,
         price: float,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_manifest import ManifestManager
-            return await ManifestManager.place_batch_orders(self, market_id, quantity, side, price)
+
+            return await ManifestManager.place_batch_orders(
+                self, market_id, quantity, side, price
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to place limit order: {e}")
-        
+
     async def place_batch_orders(
-        self, 
+        self,
         market_id: str,
         orders: List[Dict[str, Any]],
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_manifest import ManifestManager
+
             return await ManifestManager.place_batch_orders(self, market_id, orders)
         except Exception as e:
             raise AgentKitError(f"Failed to place batch orders: {e}")
-        
+
     async def cancel_all_orders(
-        self, 
+        self,
         market_id: str,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_manifest import ManifestManager
+
             return await ManifestManager.cancel_all_orders(self, market_id)
         except Exception as e:
             raise AgentKitError(f"Failed to cancel all orders: {e}")
-        
+
     async def withdraw_all(
-        self, 
+        self,
         market_id: str,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_manifest import ManifestManager
+
             return await ManifestManager.withdraw_all(self, market_id)
         except Exception as e:
             raise AgentKitError(f"Failed to withdraw all: {e}")
-            
+
     async def create_openbook_market(
-        self, 
+        self,
         base_mint: str,
         quote_mint: str,
         lot_size: Optional[float] = 1,
         tick_size: Optional[float] = 0.01,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_openpook import OpenBookManager
-            return await OpenBookManager.create_market(self, base_mint, quote_mint, lot_size, tick_size)
+
+            return await OpenBookManager.create_market(
+                self, base_mint, quote_mint, lot_size, tick_size
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create openbook market: {e}")
-        
+
     async def close_position(
-        self, 
+        self,
         position_mint_address: str,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_orca import OrcaManager
+
             return await OrcaManager.close_position(self, position_mint_address)
         except Exception as e:
             raise AgentKitError(f"Failed to close position: {e}")
-        
-    
+
     async def create_clmm(
-        self, 
+        self,
         mint_deploy: str,
         mint_pair: str,
         initial_price: float,
         fee_tier: str,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_orca import OrcaManager
-            return await OrcaManager.close_position(self, mint_deploy, mint_pair, initial_price, fee_tier)
+
+            return await OrcaManager.close_position(
+                self, mint_deploy, mint_pair, initial_price, fee_tier
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create clmm: {e}")
-    
+
     async def create_liquidity_pool(
-        self, 
+        self,
         deposit_token_amount: float,
         deposit_token_mint: str,
         other_token_mint: str,
         initial_price: float,
         max_price: float,
         fee_tier: str,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_orca import OrcaManager
-            return await OrcaManager.create_liquidity_pool(self, deposit_token_amount, deposit_token_mint, other_token_mint, initial_price, max_price, fee_tier)
+
+            return await OrcaManager.create_liquidity_pool(
+                self,
+                deposit_token_amount,
+                deposit_token_mint,
+                other_token_mint,
+                initial_price,
+                max_price,
+                fee_tier,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create liquidity pool: {e}")
-    
-    async def fetch_positions(
-        self
-        ) -> Optional[Dict[str, Any]]:
+
+    async def fetch_positions(self) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_orca import OrcaManager
+
             return await OrcaManager.fetch_positions(self)
         except Exception as e:
             raise AgentKitError(f"Failed to close position: {e}")
-    
+
     async def open_centered_position(
-        self, 
+        self,
         whirlpool_address: str,
         price_offset_bps: int,
         input_token_mint: str,
         input_amount: float,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_orca import OrcaManager
-            return await OrcaManager.open_centered_position(self, whirlpool_address, price_offset_bps, input_token_mint, input_amount)
+
+            return await OrcaManager.open_centered_position(
+                self,
+                whirlpool_address,
+                price_offset_bps,
+                input_token_mint,
+                input_amount,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to open centered position: {e}")
-        
+
     async def open_single_sided_position(
-        self, 
+        self,
         whirlpool_address: str,
         distance_from_current_price_bps: int,
         width_bps: int,
         input_token_mint: str,
         input_amount: float,
-        ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Dict[str, Any]]:
         try:
             from agentipy.tools.use_orca import OrcaManager
-            return await OrcaManager.open_single_sided_position(self, whirlpool_address, distance_from_current_price_bps, width_bps, input_token_mint, input_amount)
+
+            return await OrcaManager.open_single_sided_position(
+                self,
+                whirlpool_address,
+                distance_from_current_price_bps,
+                width_bps,
+                input_token_mint,
+                input_amount,
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to open single sided position: {e}")
 
@@ -2171,11 +2752,11 @@ class SolanaAgentKit:
             dict: Trending tokens data.
         """
         from agentipy.tools.use_coingecko import CoingeckoManager
+
         try:
             return await CoingeckoManager.get_trending_tokens(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch trending tokens: {e}")
-
 
     async def get_trending_pools(self, duration: str = "24h"):
         """
@@ -2188,13 +2769,15 @@ class SolanaAgentKit:
             dict: Trending pools data.
         """
         from agentipy.tools.use_coingecko import CoingeckoManager
+
         try:
             return await CoingeckoManager.get_trending_pools(self, duration)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch trending pools: {e}")
 
-
-    async def get_top_gainers(self, duration: str = "24h", top_coins: int | str = "all"):
+    async def get_top_gainers(
+        self, duration: str = "24h", top_coins: int | str = "all"
+    ):
         """
         Get top gainers from CoinGecko.
 
@@ -2206,11 +2789,11 @@ class SolanaAgentKit:
             dict: Top gainers data.
         """
         from agentipy.tools.use_coingecko import CoingeckoManager
+
         try:
             return await CoingeckoManager.get_top_gainers(self, duration, top_coins)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch top gainers: {e}")
-
 
     async def get_token_price_data(self, token_addresses: list[str]):
         """
@@ -2223,6 +2806,7 @@ class SolanaAgentKit:
             dict: Token price data from CoinGecko.
         """
         from agentipy.tools.use_coingecko import CoingeckoManager
+
         try:
             return await CoingeckoManager.get_token_price_data(self, token_addresses)
         except Exception as e:
@@ -2239,11 +2823,11 @@ class SolanaAgentKit:
             dict: Token info data.
         """
         from agentipy.tools.use_coingecko import CoingeckoManager
+
         try:
             return await CoingeckoManager.get_token_info(self, token_address)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch token info: {e}")
-
 
     async def get_latest_pools(self):
         """
@@ -2253,12 +2837,13 @@ class SolanaAgentKit:
             dict: Latest pools data.
         """
         from agentipy.tools.use_coingecko import CoingeckoManager
+
         try:
             return await CoingeckoManager.get_latest_pools(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch latest pools: {e}")
-        
-    async def ping_elfa_ai_api(self) -> dict :
+
+    async def ping_elfa_ai_api(self) -> dict:
         """
         Ping the Elfa AI API.
 
@@ -2266,12 +2851,13 @@ class SolanaAgentKit:
             dict: API response.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
             return await ElfaAiManager.ping_elfa_ai_api(self)
         except Exception as e:
             raise AgentKitError(f"Failed to ping Elfa AI API: {e}")
-        
-    async def get_elfa_ai_api_key_status(self) -> dict :
+
+    async def get_elfa_ai_api_key_status(self) -> dict:
         """
         Get the Elfa AI API key status.
 
@@ -2279,11 +2865,12 @@ class SolanaAgentKit:
             dict: API key status.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
             return await ElfaAiManager.get_elfa_ai_api_key_status(self)
         except Exception as e:
             raise AgentKitError(f"Failed to get Elfa AI API key status: {e}")
-        
+
     async def get_smart_mentions(self, limit: int = 100, offset: int = 0) -> dict:
         """
         Get smart mentions from Elfa AI.
@@ -2297,17 +2884,20 @@ class SolanaAgentKit:
             dict: Mentions data.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
             return await ElfaAiManager.get_smart_mentions(self, limit, offset)
         except Exception as e:
             raise AgentKitError(f"Failed to get smart mentions: {e}")
-        
-    async def get_top_mentions_by_ticker(self, ticker: str,
+
+    async def get_top_mentions_by_ticker(
+        self,
+        ticker: str,
         time_window: str = "1h",
         page: int = 1,
         page_size: int = 10,
-        include_account_details: bool = False
-        ) -> dict:
+        include_account_details: bool = False,
+    ) -> dict:
         """
         Get top mentions by ticker.
 
@@ -2323,17 +2913,22 @@ class SolanaAgentKit:
             dict: Mentions data.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
-            return await ElfaAiManager.get_top_mentions_by_ticker(self, ticker, time_window, page, page_size, include_account_details)
+            return await ElfaAiManager.get_top_mentions_by_ticker(
+                self, ticker, time_window, page, page_size, include_account_details
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to get top mentions by ticker: {e}")
-        
+
     async def search_mentions_by_keywords(
-        self,keywords: str,
+        self,
+        keywords: str,
         from_timestamp: int,
         to_timestamp: int,
         limit: int = 20,
-        cursor: str = None) -> dict:
+        cursor: str = None,
+    ) -> dict:
         """
         Search mentions by keywords.
 
@@ -2349,17 +2944,20 @@ class SolanaAgentKit:
             dict: Search results.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
-            return await ElfaAiManager.search_mentions_by_keywords(self, keywords, from_timestamp, to_timestamp, limit, cursor)
+            return await ElfaAiManager.search_mentions_by_keywords(
+                self, keywords, from_timestamp, to_timestamp, limit, cursor
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to search mentions by keywords: {e}")
-        
+
     async def get_trending_tokens_using_elfa_ai(
         self,
         time_window: str = "24h",
         page: int = 1,
         page_size: int = 50,
-        min_mentions: int = 5
+        min_mentions: int = 5,
     ) -> dict:
         """
         Get trending tokens using Elfa AI.
@@ -2375,11 +2973,14 @@ class SolanaAgentKit:
             dict: Trending tokens data.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
-            return await ElfaAiManager.get_trending_tokens_using_elfa_ai(self, time_window, page, page_size, min_mentions)
+            return await ElfaAiManager.get_trending_tokens_using_elfa_ai(
+                self, time_window, page, page_size, min_mentions
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to get trending tokens using Elfa AI: {e}")
-        
+
     async def get_smart_twitter_account_stats(self, username: str) -> dict:
         """
         Get smart Twitter account stats.
@@ -2392,17 +2993,18 @@ class SolanaAgentKit:
             dict: Account statistics data.
         """
         from agentipy.tools.use_elfa_ai import ElfaAiManager
+
         try:
             return await ElfaAiManager.get_smart_twitter_account_stats(self, username)
         except Exception as e:
             raise AgentKitError(f"Failed to get smart Twitter account stats: {e}")
-    
+
     async def fluxbeam_create_pool(
         self,
         token_a: Pubkey,
         token_a_amount: float,
         token_b: Pubkey,
-        token_b_amount: float
+        token_b_amount: float,
     ) -> str:
         """
         Create a new pool using FluxBeam.
@@ -2418,14 +3020,20 @@ class SolanaAgentKit:
             str: Transaction signature.
         """
         from agentipy.tools.use_fluxbeam import FluxBeamManager
+
         try:
-            return await FluxBeamManager.fluxbeam_create_pool(self, token_a, token_a_amount, token_b, token_b_amount)
+            return await FluxBeamManager.fluxbeam_create_pool(
+                self, token_a, token_a_amount, token_b, token_b_amount
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to create pool using FluxBeam: {e}")
-    
-    async def get_price_prediction(self, asset: PriceInferenceToken,
-    timeframe: PriceInferenceTimeframe,
-    signature_format: SignatureFormat = SignatureFormat.ETHEREUM_SEPOLIA):
+
+    async def get_price_prediction(
+        self,
+        asset: PriceInferenceToken,
+        timeframe: PriceInferenceTimeframe,
+        signature_format: SignatureFormat = SignatureFormat.ETHEREUM_SEPOLIA,
+    ):
         """
         Fetch a future price prediction for BTC or ETH for a given timeframe (5m or 8h) from the Allora Network.
 
@@ -2434,11 +3042,14 @@ class SolanaAgentKit:
         :return: A dictionary containing the predicted price and confidence interval.
         """
         from agentipy.tools.use_allora import AlloraManager
+
         try:
-            return await AlloraManager.get_price_prediction(self, asset, timeframe, signature_format)
+            return await AlloraManager.get_price_prediction(
+                self, asset, timeframe, signature_format
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to fetch price prediction: {e}")
-        
+
     async def get_inference_by_topic_id(self, topic_id: int):
         """
         Fetch a price inference for BTC or ETH for a given timeframe (5m or 8h) from the Allora Network.
@@ -2448,11 +3059,12 @@ class SolanaAgentKit:
         :return: A dictionary containing the predicted price and confidence interval.
         """
         from agentipy.tools.use_allora import AlloraManager
+
         try:
             return await AlloraManager.get_inference_by_topic_id(self, topic_id)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch price inference: {e}")
-    
+
     async def get_all_topics(self):
         """
         Fetch all topics from the Allora Network.
@@ -2460,11 +3072,12 @@ class SolanaAgentKit:
         :return: A list of topic IDs.
         """
         from agentipy.tools.use_allora import AlloraManager
+
         try:
             return await AlloraManager.get_all_topics(self)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch all topics: {e}")
-        
+
     async def restake(self, amount: float):
         """
         Restake all rewards.
@@ -2472,12 +3085,13 @@ class SolanaAgentKit:
         :return: A dictionary containing the transaction signature.
         """
         from agentipy.tools.use_solayer import SolayerManager
+
         try:
-            return await SolayerManager.stake_with_solayer(self,amount)
+            return await SolayerManager.stake_with_solayer(self, amount)
         except Exception as e:
             raise AgentKitError(f"Failed to restake all rewards: {e}")
-        
-    async def rock_paper_scissors(self, amount:float, choice: str):
+
+    async def rock_paper_scissors(self, amount: float, choice: str):
         """
         Play rock-paper-scissors with the Solana agent.
 
@@ -2486,11 +3100,12 @@ class SolanaAgentKit:
         :return: A dictionary containing the game result.
         """
         from agentipy.tools.use_sendarcade import SendArcadeManager
+
         try:
             return await SendArcadeManager.rock_paper_scissor(self, amount, choice)
         except Exception as e:
             raise AgentKitError(f"Failed to play rock-paper-scissors: {e}")
-        
+
     def close_accounts(
         self,
         mints: List[str],
@@ -2506,10 +3121,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_solutiofi import SolutiofiManager
+
             return SolutiofiManager.close_accounts(self, mints)
         except Exception as e:
             raise AgentKitError(f"Failed to close accounts: {e}")
-        
+
     def burn_tokens(
         self,
         mints: List[str],
@@ -2525,10 +3141,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_solutiofi import SolutiofiManager
+
             return SolutiofiManager.burn_tokens(self, mints)
         except Exception as e:
             raise AgentKitError(f"Failed to burn tokens: {e}")
-        
+
     def merge_tokens(
         self,
         input_assets: List[Dict[str, Any]],
@@ -2548,10 +3165,13 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_solutiofi import SolutiofiManager
-            return SolutiofiManager.merge_tokens(self, input_assets, output_mint, priority_fee)
+
+            return SolutiofiManager.merge_tokens(
+                self, input_assets, output_mint, priority_fee
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to merge tokens: {e}")
-        
+
     def spread_token(
         self,
         input_asset: Dict[str, Any],
@@ -2571,10 +3191,13 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_solutiofi import SolutiofiManager
-            return SolutiofiManager.spread_token(self, input_asset, target_tokens, priority_fee)
+
+            return SolutiofiManager.spread_token(
+                self, input_asset, target_tokens, priority_fee
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to spread token: {e}")
-        
+
     def approve_multisig_proposal(
         self,
         transaction_index: int,
@@ -2591,10 +3214,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
+
             return SquadsManager.approve_multisig_proposal(self, transaction_index)
         except Exception as e:
             raise AgentKitError(f"Failed to approve multisig proposal: {e}")
-        
+
     def create_squads_multisig(
         self,
         creator: str,
@@ -2611,10 +3235,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
+
             return SquadsManager.create_squads_multisig(self, creator)
         except Exception as e:
             raise AgentKitError(f"Failed to create Squads multisig wallet: {e}")
-        
+
     def create_multisig_proposal(
         self,
         transaction_index: int,
@@ -2631,10 +3256,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
+
             return SquadsManager.create_multisig_proposal(self, transaction_index)
         except Exception as e:
             raise AgentKitError(f"Failed to create multisig proposal: {e}")
-        
+
     def deposit_to_multisig_treasury(
         self,
         amount: float,
@@ -2655,10 +3281,13 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
-            return SquadsManager.deposit_to_multisig_treasury(self, amount, vault_index, mint)
+
+            return SquadsManager.deposit_to_multisig_treasury(
+                self, amount, vault_index, mint
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to deposit to multisig treasury: {e}")
-        
+
     def execute_multisig_proposal(
         self,
         transaction_index: int,
@@ -2675,10 +3304,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
+
             return SquadsManager.execute_multisig_proposal(self, transaction_index)
         except Exception as e:
             raise AgentKitError(f"Failed to execute multisig proposal: {e}")
-        
+
     def reject_multisig_proposal(
         self,
         transaction_index: int,
@@ -2695,10 +3325,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
+
             return SquadsManager.reject_multisig_proposal(self, transaction_index)
         except Exception as e:
             raise AgentKitError(f"Failed to reject multisig proposal: {e}")
-        
+
     def transfer_from_multisig_treasury(
         self,
         amount: float,
@@ -2721,10 +3352,13 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_squads import SquadsManager
-            return SquadsManager.transfer_from_multisig_treasury(self, amount, to, vault_index, mint)
+
+            return SquadsManager.transfer_from_multisig_treasury(
+                self, amount, to, vault_index, mint
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to transfer from multisig treasury: {e}")
-        
+
     def simulate_switchboard_feed(
         self,
         feed: str,
@@ -2743,10 +3377,13 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_switchboard import SwitchboardManager
-            return SwitchboardManager.simulate_switchboard_feed(self, feed, crossbar_url)
+
+            return SwitchboardManager.simulate_switchboard_feed(
+                self, feed, crossbar_url
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to simulate Switchboard feed: {e}")
-    
+
     def list_nft_for_sale(
         self,
         price: float,
@@ -2765,10 +3402,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_tensor import TensorManager
+
             return TensorManager.list_nft_for_sale(self, price, nft_mint)
         except Exception as e:
             raise AgentKitError(f"Failed to list NFT for sale: {e}")
-        
+
     def cancel_listing(
         self,
         nft_mint: str,
@@ -2785,10 +3423,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_tensor import TensorManager
+
             return TensorManager.cancel_listing(self, nft_mint)
         except Exception as e:
             raise AgentKitError(f"Failed to cancel listing: {e}")
-        
+
     def create_tiplink(
         self,
         amount: float,
@@ -2807,10 +3446,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_tiplink import TiplinkManager
+
             return TiplinkManager.create_tiplink(self, amount, spl_mint_address)
         except Exception as e:
             raise AgentKitError(f"Failed to create TipLink: {e}")
-        
+
     def deposit_strategy(
         self,
         deposit_amount: str,
@@ -2831,10 +3471,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_voltr import VoltrManager
+
             return VoltrManager.deposit_strategy(self, deposit_amount, vault, strategy)
         except Exception as e:
             raise AgentKitError(f"Failed to deposit to strategy: {e}")
-        
+
     def get_position_values(self, vault: str) -> Optional[Dict[str, Any]]:
         """
         Get position values for a given vault.
@@ -2848,10 +3489,11 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_voltr import VoltrManager
+
             return VoltrManager.get_position_values(self, vault)
         except Exception as e:
             raise AgentKitError(f"Failed to get position values: {e}")
-        
+
     def withdraw_strategy(
         self,
         withdraw_amount: str,
@@ -2872,11 +3514,16 @@ class SolanaAgentKit:
         """
         try:
             from agentipy.tools.use_voltr import VoltrManager
-            return VoltrManager.withdraw_strategy(self, withdraw_amount, vault, strategy)
+
+            return VoltrManager.withdraw_strategy(
+                self, withdraw_amount, vault, strategy
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to withdraw from strategy: {e}")
-        
-    async def get_sentient_listings(self, page_number: Optional[int] = 1, page_size: Optional[int] = 30):
+
+    async def get_sentient_listings(
+        self, page_number: Optional[int] = 1, page_size: Optional[int] = 30
+    ):
         """
         Retrieves Sentient listings.
 
@@ -2888,12 +3535,15 @@ class SolanaAgentKit:
             dict: Listings data or error details.
         """
         from agentipy.tools.use_virtuals import VirtualsManager
+
         try:
-            return  VirtualsManager.get_sentient_listings(self, page_number, page_size)
+            return VirtualsManager.get_sentient_listings(self, page_number, page_size)
         except Exception as e:
             raise AgentKitError(f"Failed to fetch Sentient listings: {e}")
 
-    async def buy_sentient(self, token_address: str, amount: str, builder_id: Optional[int] = None):
+    async def buy_sentient(
+        self, token_address: str, amount: str, builder_id: Optional[int] = None
+    ):
         """
         Buys Sentient tokens.
 
@@ -2906,12 +3556,15 @@ class SolanaAgentKit:
             dict: Transaction receipt or error details.
         """
         from agentipy.tools.use_virtuals import VirtualsManager
+
         try:
-            return  VirtualsManager.buy_sentient(self, token_address, amount, builder_id)
+            return VirtualsManager.buy_sentient(self, token_address, amount, builder_id)
         except Exception as e:
             raise AgentKitError(f"Failed to buy Sentient tokens: {e}")
 
-    async def sell_sentient(self, token_address: str, amount: str, builder_id: Optional[int] = None):
+    async def sell_sentient(
+        self, token_address: str, amount: str, builder_id: Optional[int] = None
+    ):
         """
         Sells Sentient tokens.
 
@@ -2924,12 +3577,21 @@ class SolanaAgentKit:
             dict: Transaction receipt or error details.
         """
         from agentipy.tools.use_virtuals import VirtualsManager
+
         try:
-            return  VirtualsManager.sell_sentient(self, token_address, amount, builder_id)
+            return VirtualsManager.sell_sentient(
+                self, token_address, amount, builder_id
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to sell Sentient tokens: {e}")
 
-    async def buy_prototype(self, token_address: str, amount: str, builder_id: Optional[int] = None, slippage: Optional[float] = None):
+    async def buy_prototype(
+        self,
+        token_address: str,
+        amount: str,
+        builder_id: Optional[int] = None,
+        slippage: Optional[float] = None,
+    ):
         """
         Buys Prototype tokens.
 
@@ -2943,12 +3605,21 @@ class SolanaAgentKit:
             dict: Transaction receipt or error details.
         """
         from agentipy.tools.use_virtuals import VirtualsManager
+
         try:
-            return  VirtualsManager.buy_prototype(self, token_address, amount, builder_id, slippage)
+            return VirtualsManager.buy_prototype(
+                self, token_address, amount, builder_id, slippage
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to buy Prototype tokens: {e}")
 
-    async def sell_prototype(self, token_address: str, amount: str, builder_id: Optional[int] = None, slippage: Optional[float] = None):
+    async def sell_prototype(
+        self,
+        token_address: str,
+        amount: str,
+        builder_id: Optional[int] = None,
+        slippage: Optional[float] = None,
+    ):
         """
         Sells Prototype tokens.
 
@@ -2962,7 +3633,10 @@ class SolanaAgentKit:
             dict: Transaction receipt or error details.
         """
         from agentipy.tools.use_virtuals import VirtualsManager
+
         try:
-            return  VirtualsManager.sell_prototype(self, token_address, amount, builder_id, slippage)
+            return VirtualsManager.sell_prototype(
+                self, token_address, amount, builder_id, slippage
+            )
         except Exception as e:
             raise AgentKitError(f"Failed to sell Prototype tokens: {e}")

--- a/agentipy/tools/deploy_token.py
+++ b/agentipy/tools/deploy_token.py
@@ -1,25 +1,34 @@
+import base64
 import logging
 from typing import Any, Dict
-
+from solders.signature import Signature  # type: ignore
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Confirmed
 from solana.rpc.types import TxOpts
 from solders.compute_budget import set_compute_unit_price  # type: ignore
 from solders.keypair import Keypair  # type: ignore
+from solders.pubkey import Pubkey as PublicKey  # type: ignore
 from solders.message import Message, to_bytes_versioned  # type: ignore
 from solders.pubkey import Pubkey  # type: ignore
 from solders.system_program import CreateAccountParams, create_account
 from solders.transaction import Transaction  # type: ignore
 from spl.token._layouts import MINT_LAYOUT
 from spl.token.constants import TOKEN_PROGRAM_ID
-from spl.token.instructions import (InitializeMintParams, MintToParams,
-                                    create_associated_token_account,
-                                    get_associated_token_address,
-                                    initialize_mint, mint_to)
+from spl.token.instructions import (
+    InitializeMintParams,
+    MintToParams,
+    create_associated_token_account,
+    get_associated_token_address,
+    initialize_mint,
+    mint_to,
+)
 
 from agentipy.agent import SolanaAgentKit
+from agentipy.wallet.privy_wallet_client import PrivyWalletClient
+from agentipy.wallet.solana_wallet_client import SolanaTransaction, SolanaWalletClient
 
 logger = logging.getLogger(__name__)
+
 
 class TokenDeploymentManager:
     @staticmethod
@@ -38,76 +47,97 @@ class TokenDeploymentManager:
             new_mint = Keypair()
             logger.info(f"Generated mint address: {new_mint.pubkey()}")
 
-            sender = agent.wallet
-            client = agent.connection
-            sender_ata = get_associated_token_address(sender.pubkey(), new_mint.pubkey())
-
-            blockhash = await client.get_latest_blockhash()
-
-            lamports = (await client.get_minimum_balance_for_rent_exemption(MINT_LAYOUT.sizeof())).value
-
-            create_account_ix = create_account(CreateAccountParams(
-                from_pubkey=sender.pubkey(),
-                to_pubkey=new_mint.pubkey(),
-                owner=TOKEN_PROGRAM_ID,
-                lamports=lamports,
-                space=MINT_LAYOUT.sizeof(),
-            ))
-
-            initialize_mint_ix = initialize_mint(InitializeMintParams(
-                decimals=decimals,
-                freeze_authority=sender.pubkey(),
-                mint=new_mint.pubkey(),
-                mint_authority=sender.pubkey(),
-                program_id=TOKEN_PROGRAM_ID,
-            ))
-
-
-            create_associated_token_account_ix = create_associated_token_account(sender.pubkey(), sender.pubkey(), new_mint.pubkey())
-
-            amount_to_transfer = 1000000000 * 10 ** 8
-
-
-            mint_to_ix = mint_to(MintToParams(
-                amount=amount_to_transfer,
-                dest=sender_ata,
-                mint=new_mint.pubkey(),
-                mint_authority=sender.pubkey(),
-                program_id=TOKEN_PROGRAM_ID,
-            ))
-
-            message = Message([
-                create_account_ix,
-                initialize_mint_ix,
-                create_associated_token_account_ix,
-                mint_to_ix,
-            ], sender.pubkey())
-
+            sender_pubkey = PublicKey.from_string(str(agent.wallet_address))
+            sender_ata = get_associated_token_address(sender_pubkey, new_mint.pubkey())
 
             blockhash_response = await agent.connection.get_latest_blockhash()
             recent_blockhash = blockhash_response.value.blockhash
 
-            transaction = Transaction([sender, new_mint], message, recent_blockhash=recent_blockhash)
+            lamports = (
+                await agent.connection.get_minimum_balance_for_rent_exemption(
+                    MINT_LAYOUT.sizeof()
+                )
+            ).value
 
-            tx_resp = await agent.connection.send_transaction(transaction, opts=TxOpts(preflight_commitment=Confirmed))
+            create_account_ix = create_account(
+                CreateAccountParams(
+                    from_pubkey=sender_pubkey,
+                    to_pubkey=new_mint.pubkey(),
+                    owner=TOKEN_PROGRAM_ID,
+                    lamports=lamports,
+                    space=MINT_LAYOUT.sizeof(),
+                )
+            )
 
-            tx_id = tx_resp.value
+            initialize_mint_ix = initialize_mint(
+                InitializeMintParams(
+                    decimals=decimals,
+                    freeze_authority=sender_pubkey,
+                    mint=new_mint.pubkey(),
+                    mint_authority=sender_pubkey,
+                    program_id=TOKEN_PROGRAM_ID,
+                )
+            )
 
+            create_associated_token_account_ix = create_associated_token_account(
+                sender_pubkey, sender_pubkey, new_mint.pubkey()
+            )
+
+            amount_to_transfer = 1000000000 * 10**8
+
+            mint_to_ix = mint_to(
+                MintToParams(
+                    amount=amount_to_transfer,
+                    dest=sender_ata,
+                    mint=new_mint.pubkey(),
+                    mint_authority=sender_pubkey,
+                    program_id=TOKEN_PROGRAM_ID,
+                )
+            )
+
+            instructions = [
+                create_account_ix,
+                initialize_mint_ix,
+                create_associated_token_account_ix,
+                mint_to_ix,
+            ]
+
+            # Detect Wallet Client Type
+            if isinstance(agent.wallet_client, PrivyWalletClient):
+                transaction = Transaction()
+                for instruction in instructions:
+                    transaction.add(instruction)
+                transaction.recent_blockhash = recent_blockhash
+                # Add new_mint as signer to the transaction
+                transaction.sign_partial(new_mint)
+                serialized_transaction = transaction.serialize(verify_signatures=False)
+                transaction_base64 = base64.b64encode(serialized_transaction).decode(
+                    "utf-8"
+                )
+                res = await agent.wallet_client.send_transaction(transaction_base64)
+                tx_id = res.get("hash", "tx_id")
+            elif isinstance(agent.wallet_client, SolanaWalletClient):
+                solana_tx = SolanaTransaction(
+                    instructions=instructions, signers=[new_mint]
+                )
+                res = await agent.wallet_client.send_transaction(solana_tx)
+                tx_id = res.get("hash", "tx_id")
+            else:
+                # Fallback for other wallet types
+                raise ValueError(
+                    f"Unsupported wallet client type: {type(agent.wallet_client).__name__}"
+                )
+
+            logger.info(f"Transaction Signature: {tx_id}")
             await agent.connection.confirm_transaction(
                 tx_id,
                 commitment=Confirmed,
-                last_valid_block_height=blockhash.value.last_valid_block_height,
+                last_valid_block_height=blockhash_response.value.last_valid_block_height,
             )
-
-            logger.info(f"https://explorer.solana.com/tx/{tx_resp}")
-
-            await client.close()
-
-            logger.info(f"Transaction Signature: {tx_resp}")
 
             return {
                 "mint": str(new_mint.pubkey()),
-                "signature": tx_resp,
+                "signature": tx_id,
             }
 
         except Exception as e:

--- a/agentipy/tools/evm/use_uniswap.py
+++ b/agentipy/tools/evm/use_uniswap.py
@@ -3,10 +3,11 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from agentipy.agent.evm import EvmAgentKit
+from agentipy.agent.evm import EvmAgentKit, WalletType
 from agentipy.utils.agentipy_proxy.utils import encrypt_private_key
 
 logger = logging.getLogger(__name__)
+
 
 class UniswapManager:
     """
@@ -22,7 +23,9 @@ class UniswapManager:
         input_token_decimals: int = 18,
         output_token_decimals: int = 18,
         slippage: float = 0.5,
-        fee_amount: Optional[int] = 3000,  # Medium fee as default (corresponds to FeeAmount.MEDIUM in TS)
+        fee_amount: Optional[
+            int
+        ] = 3000,  # Medium fee as default (corresponds to FeeAmount.MEDIUM in TS)
     ) -> Optional[Dict[str, Any]]:
         """
         Retrieves a quote from Uniswap for swapping between two tokens.
@@ -42,15 +45,15 @@ class UniswapManager:
                 "rpc_url": agent.rpc_url,
                 "inputToken": {
                     "address": input_token_address,
-                    "decimals": input_token_decimals
+                    "decimals": input_token_decimals,
                 },
                 "outputToken": {
                     "address": output_token_address,
-                    "decimals": output_token_decimals
+                    "decimals": output_token_decimals,
                 },
                 "amountInRaw": amount_in_raw,
                 "slippage": slippage,
-                "feeAmount": fee_amount
+                "feeAmount": fee_amount,
             }
 
             response = requests.post(
@@ -63,21 +66,29 @@ class UniswapManager:
             data = response.json()
             if data.get("success"):
                 return {
-                    "success": True, 
+                    "success": True,
                     "value": data.get("value"),
                     "message": data.get("message"),
-                    "min_output_amount": data.get("message")  # The TS endpoint returns the min output amount in the message field
+                    "min_output_amount": data.get(
+                        "message"
+                    ),  # The TS endpoint returns the min output amount in the message field
                 }
             else:
                 return {"success": False, "error": data.get("error", "Unknown error")}
 
         except requests.exceptions.RequestException as http_error:
-            logger.error(f"HTTP error during Uniswap quote retrieval: {http_error}", exc_info=True)
+            logger.error(
+                f"HTTP error during Uniswap quote retrieval: {http_error}",
+                exc_info=True,
+            )
             return {"success": False, "error": str(http_error)}
         except Exception as error:
-            logger.error(f"Unexpected error during Uniswap quote retrieval: {error}", exc_info=True)
+            logger.error(
+                f"Unexpected error during Uniswap quote retrieval: {error}",
+                exc_info=True,
+            )
             return {"success": False, "error": str(error)}
-            
+
     @staticmethod
     def trade(
         agent: EvmAgentKit,
@@ -87,7 +98,9 @@ class UniswapManager:
         input_token_decimals: int = 18,
         output_token_decimals: int = 18,
         slippage: float = 0.5,
-        fee_amount: Optional[int] = 3000,  # Medium fee as default (corresponds to FeeAmount.MEDIUM in TS)
+        fee_amount: Optional[
+            int
+        ] = 3000,  # Medium fee as default (corresponds to FeeAmount.MEDIUM in TS)
     ) -> Optional[Dict[str, Any]]:
         """
         Executes a token swap on Uniswap.
@@ -103,52 +116,76 @@ class UniswapManager:
         :return: Transaction details or error information.
         """
         try:
-            encrypted_private_key = encrypt_private_key(agent.private_key)
-            
-            payload = {
-                "requestId": encrypted_private_key["requestId"],
-                "encrypted_private_key": encrypted_private_key["encryptedPrivateKey"],
+            base_payload = {
                 "rpc_url": agent.rpc_url,
                 "inputToken": {
                     "address": input_token_address,
-                    "decimals": input_token_decimals
+                    "decimals": input_token_decimals,
                 },
                 "outputToken": {
                     "address": output_token_address,
-                    "decimals": output_token_decimals
+                    "decimals": output_token_decimals,
                 },
                 "amountInRaw": amount_in_raw,
                 "slippage": slippage,
-                "feeAmount": fee_amount
+                "feeAmount": fee_amount,
+                "chainId": agent.chain_id,
+                "walletType": agent.wallet_type,
             }
+            if agent.wallet_type == WalletType.PRIVY:
+                print("privy")
+                payload = {**base_payload, "wallet_id": agent.wallet_id}
+            elif agent.wallet_type == WalletType.PRIVATE_KEY:
+                print("private key")
+                encrypted_private_key = encrypt_private_key(agent.private_key)
+                payload = {
+                    **base_payload,
+                    "requestId": encrypted_private_key["requestId"],
+                    "encrypted_private_key": encrypted_private_key[
+                        "encryptedPrivateKey"
+                    ],
+                }
+            elif agent.wallet_type == WalletType.CROSSMINT:
+                print("crossmint")
 
             print("payload is: ", payload)
 
             response = requests.post(
-                f"{agent.base_proxy_url}/{agent.api_version}uniswap/base/trade",
+                f"{"agent.base_proxy_url"}/{agent.api_version}/uniswap/base/trade",
                 json=payload,
                 headers={"Content-Type": "application/json"},
             )
             response.raise_for_status()
 
             data = response.json()
+            print("data is: ", data)
             if data.get("success"):
                 return {
-                    "success": True, 
+                    "success": True,
                     "value": data.get("value"),
                     "message": data.get("message"),
-                    "transaction_hash": data.get("message").split("Hash: ")[1] if "Hash: " in data.get("message", "") else None
+                    "transaction_hash": (
+                        data.get("message").split("Hash: ")[1]
+                        if "Hash: " in data.get("message", "")
+                        else None
+                    ),
                 }
             else:
                 return {
-                    "success": False, 
-                    "error": data.get("error", "Unknown error"), 
-                    "details": data.get("details")
+                    "success": False,
+                    "error": data.get("error", "Unknown error"),
+                    "details": data.get("details"),
                 }
 
         except requests.exceptions.RequestException as http_error:
-            logger.error(f"HTTP error during Uniswap trade execution: {http_error}", exc_info=True)
+            logger.error(
+                f"HTTP error during Uniswap trade execution: {http_error}",
+                exc_info=True,
+            )
             return {"success": False, "error": str(http_error)}
         except Exception as error:
-            logger.error(f"Unexpected error during Uniswap trade execution: {error}", exc_info=True)
+            logger.error(
+                f"Unexpected error during Uniswap trade execution: {error}",
+                exc_info=True,
+            )
             return {"success": False, "error": str(error)}

--- a/agentipy/tools/get_balance.py
+++ b/agentipy/tools/get_balance.py
@@ -11,8 +11,7 @@ from agentipy.constants import LAMPORTS_PER_SOL
 class BalanceFetcher:
     @staticmethod
     async def get_balance(
-        agent: SolanaAgentKit,
-        token_address: Optional[Pubkey] = None
+        agent: SolanaAgentKit, token_address: Optional[Pubkey] = None
     ) -> Optional[float]:
         """
         Get the balance of SOL or an SPL token for the agent's wallet.
@@ -29,20 +28,18 @@ class BalanceFetcher:
         """
         try:
             if not token_address:
+                print("here")
                 response = await agent.connection.get_balance(
-                    agent.wallet_address,
-                    commitment=Confirmed
+                    agent.wallet_address, commitment=Confirmed
                 )
                 return response.value / LAMPORTS_PER_SOL
 
             token_account_pubkey = get_associated_token_address(
-                owner=agent.wallet_address,
-                mint=token_address
+                owner=agent.wallet_address, mint=token_address
             )
 
             response = await agent.connection.get_token_account_balance(
-                token_account_pubkey,
-                commitment=Confirmed
+                token_account_pubkey, commitment=Confirmed
             )
 
             if response.value is None:
@@ -51,4 +48,6 @@ class BalanceFetcher:
             return float(response.value.ui_amount)
 
         except Exception as error:
-            raise Exception(f"Failed to get balance for {'SOL' if not token_address else 'SPL token'}: {str(error)}") from error
+            raise Exception(
+                f"Failed to get balance for {'SOL' if not token_address else 'SPL token'}: {str(error)}"
+            ) from error

--- a/agentipy/tools/trade.py
+++ b/agentipy/tools/trade.py
@@ -8,16 +8,19 @@ from solana.rpc.types import TxOpts
 from solders.message import to_bytes_versioned  # type: ignore
 from solders.pubkey import Pubkey  # type: ignore
 from solders.transaction import VersionedTransaction  # type: ignore
-
+from solders.signature import Signature  # type: ignore
 from agentipy.agent import SolanaAgentKit
-from agentipy.constants import (DEFAULT_OPTIONS, JUP_API, LAMPORTS_PER_SOL,
-                                TOKENS)
+from agentipy.constants import DEFAULT_OPTIONS, JUP_API, LAMPORTS_PER_SOL, TOKENS
+from agentipy.wallet.privy_wallet_client import PrivyWalletClient
+from agentipy.wallet.solana_wallet_client import SolanaWalletClient
+
 # from agentipy.helpers import fix_asyncio_for_windows #Removed because it is not needed anymore.
 
-if platform.system() == "Windows": #Added the aiodns fix.
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()) #Added the aiodns fix.
+if platform.system() == "Windows":  # Added the aiodns fix.
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 # fix_asyncio_for_windows() #Removed because it is not needed anymore.
+
 
 class TradeManager:
     @staticmethod
@@ -58,7 +61,9 @@ class TradeManager:
             async with aiohttp.ClientSession() as session:
                 async with session.get(quote_url) as quote_response:
                     if quote_response.status != 200:
-                        raise Exception(f"Failed to fetch quote: {quote_response.status}")
+                        raise Exception(
+                            f"Failed to fetch quote: {quote_response.status}"
+                        )
                     quote_data = await quote_response.json()
 
                 async with session.post(
@@ -72,25 +77,46 @@ class TradeManager:
                     },
                 ) as swap_response:
                     if swap_response.status != 200:
-                        raise Exception(f"Failed to fetch swap transaction: {swap_response.status}")
+                        raise Exception(
+                            f"Failed to fetch swap transaction: {swap_response.status}"
+                        )
                     swap_data = await swap_response.json()
-
-            swap_transaction_buf = base64.b64decode(swap_data["swapTransaction"])
-            transaction = VersionedTransaction.from_bytes(swap_transaction_buf)
 
             latest_blockhash = await agent.connection.get_latest_blockhash()
 
-            signature = agent.wallet.sign_message(to_bytes_versioned(transaction.message))
-            signed_transaction = VersionedTransaction.populate(transaction.message, [signature])
+            if isinstance(agent.wallet_client, PrivyWalletClient):
+                res = await agent.wallet_client.send_transaction(
+                    swap_data["swapTransaction"]
+                )
+                tx_id = res.get("hash", "tx_id")
+            elif isinstance(agent.wallet_client, SolanaWalletClient):
+                swap_transaction_buf = base64.b64decode(swap_data["swapTransaction"])
+                transaction = VersionedTransaction.from_bytes(swap_transaction_buf)
 
-            tx_resp = await agent.connection.send_transaction(
-                signed_transaction,
-                opts=TxOpts(preflight_commitment=Confirmed, skip_preflight=False, max_retries=3),
-            )
-            tx_id = tx_resp.value
+                signature = agent.wallet.sign_message(
+                    to_bytes_versioned(transaction.message)
+                )
+                signed_transaction = VersionedTransaction.populate(
+                    transaction.message, [signature]
+                )
+                tx_resp = await agent.connection.send_transaction(
+                    signed_transaction,
+                    opts=TxOpts(
+                        preflight_commitment=Confirmed,
+                        skip_preflight=False,
+                        max_retries=3,
+                    ),
+                )
+                tx_id = tx_resp.value
+            else:
+                # Fallback for other wallet types
+                raise ValueError(
+                    f"Unsupported wallet client type: {type(agent.wallet_client).__name__}"
+                )
 
+            signature = Signature.from_string(tx_id)
             await agent.connection.confirm_transaction(
-                tx_id,
+                tx_sig=signature,
                 commitment=Confirmed,
                 last_valid_block_height=latest_blockhash.value.last_valid_block_height,
             )

--- a/agentipy/tools/transfer.py
+++ b/agentipy/tools/transfer.py
@@ -10,10 +10,14 @@ from solana.transaction import Transaction  # type: ignore
 from spl.token.async_client import AsyncToken
 from spl.token.constants import TOKEN_PROGRAM_ID
 from spl.token.instructions import get_associated_token_address, transfer_checked
+from typing import Union
 from solders.null_signer import NullSigner
 from agentipy.agent import SolanaAgentKit
+from agentipy.agent.evm import EvmAgentKit
 from agentipy.wallet.privy_wallet_client import PrivyWalletClient
 from agentipy.wallet.solana_wallet_client import SolanaWalletClient, SolanaTransaction
+from agentipy.wallet.evm_wallet_client import EVMTransaction
+from web3 import Web3
 import base64
 
 LAMPORTS_PER_SOL = 10**9
@@ -23,93 +27,172 @@ logger = logging.getLogger(__name__)
 
 class TokenTransferManager:
     @staticmethod
-    async def transfer(
-        agent: SolanaAgentKit, to: str, amount: float, mint: str = None
+    async def transfer_evm(
+        agent: EvmAgentKit, to: str, amount: float, token_address: str = None
     ) -> str:
         """
-        Transfer SOL or SPL tokens to a recipient.
+        Transfer native EVM currency or ERC20 tokens to a recipient using Privy.
         """
         try:
-            print(
-                f"Transferring {amount} {'SPL' if mint else 'SOL'} to {to} from {agent.wallet_address}"
-            )
-            to_pubkey = PublicKey.from_string(to)
-            from_pubkey = PublicKey.from_string(str(agent.wallet_address))
+            amount_in_wei = Web3.to_wei(amount, "ether")
 
-            blockhash_resp = await agent.connection.get_latest_blockhash()
-            recent_blockhash = blockhash_resp.value.blockhash
-
-            instructions = []
-
-            if mint is None:
-                instructions.append(
-                    transfer(
-                        TransferParams(
-                            from_pubkey=from_pubkey,
-                            to_pubkey=to_pubkey,
-                            lamports=int(amount * LAMPORTS_PER_SOL),
-                        )
-                    )
+            if token_address:
+                # TODO: Implement ERC20 transfer logic
+                # This would involve constructing the transaction data for the 'transfer' function
+                # of the ERC20 contract.
+                raise NotImplementedError(
+                    "ERC20 token transfers are not yet implemented."
                 )
             else:
-                mint_pubkey = PublicKey.from_string(mint)
-
-                async with AsyncClient(agent.rpc_url) as client:
-                    token = AsyncToken(client, mint_pubkey)
-
-                    from_ata = await token.get_associated_token_address(from_pubkey)
-                    to_ata = await token.get_associated_token_address(to_pubkey)
-
-                    resp = await client.get_account_info(to_ata)
-                    if resp.value is None:
-                        from spl.token.instructions import (
-                            create_associated_token_account,
-                        )
-
-                        ata_ix = create_associated_token_account(
-                            from_pubkey, to_pubkey, mint_pubkey
-                        )
-                        instructions.append(ata_ix)
-
-                    mint_info = await token.get_mint_info()
-                    adjusted_amount = int(amount * (10**mint_info.decimals))
-
-                    instructions.append(
-                        transfer_checked(
-                            source=from_ata,
-                            dest=to_ata,
-                            owner=from_pubkey,
-                            amount=adjusted_amount,
-                            decimals=mint_info.decimals,
-                            mint=mint_pubkey,
-                            program_id=TOKEN_PROGRAM_ID,
-                        )
-                    )
-
-            # Detect Wallet Client Type
-            if isinstance(agent.wallet_client, PrivyWalletClient):
-                transaction = Transaction()
-                for instruction in instructions:
-                    transaction.add(instruction)
-                transaction.recent_blockhash = recent_blockhash
-                serialized_transaction = transaction.serialize(verify_signatures=False)
-                transaction_base64 = base64.b64encode(serialized_transaction).decode(
-                    "utf-8"
+                # Native currency transfer
+                evm_tx = EVMTransaction(
+                    to=to,
+                    value=amount_in_wei,
+                    data="0x",  # No data for native transfer
+                    gas=None,  # Let Privy handle gas estimation
                 )
-                res = await agent.wallet_client.send_transaction(transaction_base64)
-                tx_id = res.get("hash", "tx_id")
-            elif isinstance(agent.wallet_client, SolanaWalletClient):
-                solana_tx = SolanaTransaction(instructions=instructions)
-                res = await agent.wallet_client.send_transaction(solana_tx)
-                tx_id = res.get("hash", "tx_id")
-            else:
-                # Fallback for other wallet types
+
+            if not isinstance(agent.wallet_client, PrivyWalletClient):
                 raise ValueError(
-                    f"Unsupported wallet client type: {type(agent.wallet_client).__name__}"
+                    f"Unsupported wallet client type for EVM transfer: {type(agent.wallet_client).__name__}"
                 )
 
-            logging.info(f"Transaction Signature: {tx_id}")
-            return str(tx_id)
+            res = await agent.wallet_client.send_transaction(evm_tx)
+            tx_hash = res.get("hash")
+
+            if not tx_hash:
+                raise RuntimeError("Transaction failed, no hash returned.")
+
+            logging.info(f"EVM Transaction Hash: {tx_hash}")
+            return str(tx_hash)
 
         except Exception as e:
-            raise RuntimeError(f"Transfer failed: {str(e)}")
+            raise RuntimeError(f"EVM Transfer failed: {str(e)}")
+
+    @staticmethod
+    async def transfer(
+        agent: Union[SolanaAgentKit, EvmAgentKit],
+        to: str,
+        amount: float,
+        mint_or_token_address: str = None,
+    ) -> str:
+        """
+        Transfer tokens or native currency based on the agent type.
+        For SolanaAgentKit: Transfers SOL or SPL tokens. `mint_or_token_address` is the mint address for SPL tokens.
+        For EvmAgentKit: Transfers native EVM currency or ERC20 tokens. `mint_or_token_address` is the token contract address for ERC20.
+        """
+        if isinstance(agent, EvmAgentKit):
+            # Handle EVM transfer
+            return await TokenTransferManager.transfer_evm(
+                agent, to, amount, token_address=mint_or_token_address
+            )
+        elif isinstance(agent, SolanaAgentKit):
+            # Handle Solana transfer (existing logic)
+            try:
+                print(
+                    f"Transferring {amount} {'SPL' if mint_or_token_address else 'SOL'} to {to} from {agent.wallet_address}"
+                )
+                to_pubkey = PublicKey.from_string(to)
+                from_pubkey = PublicKey.from_string(str(agent.wallet_address))
+
+                blockhash_resp = await agent.connection.get_latest_blockhash()
+                recent_blockhash = blockhash_resp.value.blockhash
+
+                instructions = []
+
+                if mint_or_token_address is None:
+                    # SOL Transfer
+                    instructions.append(
+                        transfer(
+                            TransferParams(
+                                from_pubkey=from_pubkey,
+                                to_pubkey=to_pubkey,
+                                lamports=int(amount * LAMPORTS_PER_SOL),
+                            )
+                        )
+                    )
+                else:
+                    # SPL Token Transfer
+                    mint_pubkey = PublicKey.from_string(mint_or_token_address)
+
+                    async with AsyncClient(agent.rpc_url) as client:
+                        token = AsyncToken(
+                            client, mint_pubkey, TOKEN_PROGRAM_ID, NullSigner()
+                        )  # Added NullSigner
+
+                        from_ata = get_associated_token_address(
+                            from_pubkey, mint_pubkey
+                        )  # Use sync version
+                        to_ata = get_associated_token_address(
+                            to_pubkey, mint_pubkey
+                        )  # Use sync version
+
+                        resp = await client.get_account_info(to_ata)
+                        if resp.value is None:
+                            from spl.token.instructions import (
+                                create_associated_token_account,
+                            )
+
+                            ata_ix = create_associated_token_account(
+                                from_pubkey, to_pubkey, mint_pubkey
+                            )
+                            instructions.append(ata_ix)
+
+                        mint_info = await token.get_mint_info()
+                        adjusted_amount = int(amount * (10**mint_info.decimals))
+
+                        instructions.append(
+                            transfer_checked(
+                                source=from_ata,
+                                dest=to_ata,
+                                owner=from_pubkey,
+                                amount=adjusted_amount,
+                                decimals=mint_info.decimals,
+                                mint=mint_pubkey,
+                                program_id=TOKEN_PROGRAM_ID,
+                            )
+                        )
+
+                # Detect Wallet Client Type for Solana
+                if isinstance(agent.wallet_client, PrivyWalletClient):
+                    transaction = Transaction()
+                    for instruction in instructions:
+                        transaction.add(instruction)
+                    transaction.recent_blockhash = recent_blockhash
+                    transaction.fee_payer = from_pubkey  # Set fee payer
+                    serialized_transaction = transaction.serialize(
+                        verify_signatures=False
+                    )
+                    transaction_base64 = base64.b64encode(
+                        serialized_transaction
+                    ).decode("utf-8")
+                    res = await agent.wallet_client.send_transaction(transaction_base64)
+                    tx_id = res.get("hash")  # Privy returns 'hash'
+                elif isinstance(agent.wallet_client, SolanaWalletClient):
+                    solana_tx = SolanaTransaction(
+                        instructions=instructions,
+                        recent_blockhash=recent_blockhash,
+                        fee_payer=from_pubkey,
+                    )  # Pass blockhash and fee payer
+                    res = await agent.wallet_client.send_transaction(solana_tx)
+                    tx_id = res.get("signature")  # Solana client returns 'signature'
+                else:
+                    # Fallback for other wallet types
+                    raise ValueError(
+                        f"Unsupported wallet client type for Solana: {type(agent.wallet_client).__name__}"
+                    )
+
+                if not tx_id:
+                    raise RuntimeError(
+                        "Transaction failed, no signature/hash returned."
+                    )
+
+                logging.info(f"Solana Transaction Signature/Hash: {tx_id}")
+                return str(tx_id)
+
+            except Exception as e:
+                raise RuntimeError(f"Solana Transfer failed: {str(e)}")
+        else:
+            raise TypeError(
+                f"Unsupported agent type: {type(agent).__name__}. Must be SolanaAgentKit or EvmAgentKit."
+            )

--- a/agentipy/wallet/__init__.py
+++ b/agentipy/wallet/__init__.py
@@ -1,5 +1,9 @@
+from .base_wallet_client import BaseWalletClient
 from .solana_wallet_client import SolanaWalletClient
+from .privy_wallet_client import PrivyWalletClient
 
 __all__ = [
+    "BaseWalletClient",
     "SolanaWalletClient",
+    "PrivyWalletClient",
 ]

--- a/agentipy/wallet/base_wallet_client.py
+++ b/agentipy/wallet/base_wallet_client.py
@@ -1,0 +1,21 @@
+from typing import Dict, Optional, Any
+
+
+class BaseWalletClient:
+    """Base wallet implementation that defines common methods."""
+    
+    def get_address(self) -> str:
+        """Get the wallet address."""
+        raise NotImplementedError("This method must be implemented by subclasses")
+    
+    def sign_message(self, message: str) -> Dict[str, str]:
+        """Sign a message with the wallet's private key."""
+        raise NotImplementedError("This method must be implemented by subclasses")
+    
+    def balance_of(self, address: str) -> Dict:
+        """Get the balance of the specified address."""
+        raise NotImplementedError("This method must be implemented by subclasses")
+    
+    def send_transaction(self, transaction: Any) -> Dict[str, str]:
+        """Send a transaction."""
+        raise NotImplementedError("This method must be implemented by subclasses") 

--- a/agentipy/wallet/privy_wallet_client.py
+++ b/agentipy/wallet/privy_wallet_client.py
@@ -1,0 +1,184 @@
+import base64
+import json
+from typing import Dict, Optional, Any, List
+import requests
+
+from solders.pubkey import Pubkey  # type: ignore
+from solders.instruction import Instruction
+from solders.keypair import Keypair
+from solana.rpc.api import Client as SolanaClient
+from .base_wallet_client import BaseWalletClient
+from .solana_wallet_client import SolanaTransaction
+
+
+class PrivyWalletClient(BaseWalletClient):
+    """Privy wallet implementation for Solana."""
+
+    BASE_URL = "https://api.privy.io"
+
+    def __init__(self, client: SolanaClient, app_id: str, app_secret: str):
+        """
+        Initialize the Privy wallet client.
+
+        Args:
+            app_id: Privy application ID
+            app_secret: Privy application secret
+        """
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self.client = client
+        self.wallet_id = None
+        self.wallet_address = None
+
+    def _get_auth_headers(self):
+        """Get the authentication headers for Privy API requests."""
+        auth_string = f"{self.app_id}:{self.app_secret}"
+        encoded_auth = base64.b64encode(auth_string.encode()).decode()
+
+        return {
+            "Authorization": f"Basic {encoded_auth}",
+            "privy-app-id": self.app_id,
+            "Content-Type": "application/json",
+        }
+
+    def use_wallet(self, wallet_id: str) -> Dict[str, str]:
+
+        payload = {"chain_type": "solana"}
+        url = f"{self.BASE_URL}/v1/wallets/{wallet_id}"
+
+        response = requests.get(url, headers=self._get_auth_headers(), json=payload)
+        response_data = response.json()
+        print(response_data)
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to use wallet: {response_data}")
+
+        self.wallet_address = response_data["address"]
+        self.wallet_id = wallet_id
+
+        return self.wallet_address
+
+    def get_all_wallets(self) -> List[Dict[str, Any]]:
+        url = f"{self.BASE_URL}/v1/wallets"
+
+        response = requests.get(url, headers=self._get_auth_headers())
+        response_data = response.json()
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to get wallets: {response_data}")
+
+        return response_data
+
+    def create_wallet(self) -> Dict[str, str]:
+        """Create a new Solana wallet using Privy API."""
+        url = f"{self.BASE_URL}/v1/wallets"
+
+        payload = {"chain_type": "solana"}
+
+        response = requests.post(url, headers=self._get_auth_headers(), json=payload)
+        response_data = response.json()
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to create wallet: {response_data}")
+
+        self.wallet_id = response_data["id"]
+        self.wallet_address = response_data["address"]
+
+        print("wallet_id", self.wallet_id)
+
+        return {"id": self.wallet_id, "address": self.wallet_address}
+
+    def get_address(self) -> str:
+        """Get the wallet address."""
+        if not self.wallet_address:
+            raise ValueError("Wallet not initialized. Call create_wallet first.")
+        return self.wallet_address
+
+    def sign_message(self, message: str) -> Dict[str, str]:
+        """Sign a message with the wallet."""
+        if not self.wallet_id:
+            raise ValueError("Wallet not initialized. Call create_wallet first.")
+
+        url = f"{self.BASE_URL}/v1/wallets/{self.wallet_id}/rpc"
+
+        payload = {
+            "method": "signMessage",
+            "caip2": "solana:1",  # Solana mainnet
+            "chain_type": "solana",
+            "params": {"message": message},
+        }
+
+        response = requests.post(url, headers=self._get_auth_headers(), json=payload)
+        response_data = response.json()
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to sign message: {response_data}")
+
+        return {"signature": response_data["data"]["signature"]}
+
+    def balance_of(self, address: str) -> Dict:
+        pubkey = Pubkey.from_string(address)
+        balance_lamports = self.client.get_balance(pubkey).value
+        return {
+            "decimals": 9,
+            "symbol": "SOL",
+            "value": str(balance_lamports / 10**9),
+            "in_base_units": str(balance_lamports),
+        }
+
+    def send_transaction(self, transactionData) -> Dict[str, str]:
+        """Send a Solana transaction using Privy API."""
+        if not self.wallet_id:
+            raise ValueError("Wallet not initialized. Call create_wallet first.")
+
+        BASE_URL = "https://auth.privy.io"
+        url = f"{BASE_URL}/v1/wallets/{self.wallet_id}/rpc"
+
+        payload = {
+            "method": "signAndSendTransaction",
+            "caip2": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",  # Solana mainnet
+            "params": {
+                "transaction": transactionData,
+                "encoding": "base64",
+            },
+        }
+
+        try:
+            print("Sending transaction to Privy API...")
+
+            response = requests.post(
+                url, headers=self._get_auth_headers(), json=payload
+            )
+
+            print(f"Response status: {response.status_code}")
+
+            try:
+                response_data = response.json()
+                print(f"Response data: {json.dumps(response_data)}")
+
+                if response.status_code != 200:
+                    raise Exception(
+                        f"Failed to send transaction: {json.dumps(response_data)}"
+                    )
+
+                return {"hash": response_data["data"]["hash"]}
+
+            except json.JSONDecodeError:
+                print("Response is not valid JSON")
+                if response.status_code != 200:
+                    raise Exception(f"Failed to send transaction: {response.text}")
+
+        except requests.exceptions.RequestException as error:
+            print(f"Error response: {error}")
+            if hasattr(error, "response") and error.response:
+                try:
+                    error_data = error.response.json()
+                    print(f"Error response: {json.dumps(error_data)}")
+                    raise Exception(
+                        f"Failed to send transaction: {json.dumps(error_data)}"
+                    )
+                except json.JSONDecodeError:
+                    raise Exception(
+                        f"Failed to send transaction: {error.response.text}"
+                    )
+            raise error

--- a/agentipy/wallet/privy_wallet_client.py
+++ b/agentipy/wallet/privy_wallet_client.py
@@ -1,32 +1,57 @@
 import base64
 import json
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Union
 import requests
 
 from solders.pubkey import Pubkey  # type: ignore
 from solders.instruction import Instruction
 from solders.keypair import Keypair
 from solana.rpc.api import Client as SolanaClient
+from web3 import Web3
+from eth_utils.address import to_checksum_address
+from web3.types import Wei
+
 from .base_wallet_client import BaseWalletClient
 from .solana_wallet_client import SolanaTransaction
+from .evm_wallet_client import WalletClientInterface, EVMTransaction
 
 
-class PrivyWalletClient(BaseWalletClient):
-    """Privy wallet implementation for Solana."""
+class ChainType:
+    """Supported chain types in Privy"""
+
+    SOLANA = "solana"
+    EVM = "evm"
+
+
+class PrivyWalletClient(BaseWalletClient, WalletClientInterface):
+    """Privy wallet implementation for Solana and EVM chains."""
 
     BASE_URL = "https://api.privy.io"
+    AUTH_URL = "https://auth.privy.io"
 
-    def __init__(self, client: SolanaClient, app_id: str, app_secret: str):
+    def __init__(
+        self,
+        client: Union[SolanaClient, Web3],
+        app_id: str,
+        app_secret: str,
+        chain_type: str = ChainType.SOLANA,
+        chain_id: Optional[int] = None,
+    ):
         """
         Initialize the Privy wallet client.
 
         Args:
+            client: SolanaClient for Solana or Web3 for EVM
             app_id: Privy application ID
             app_secret: Privy application secret
+            chain_type: Type of blockchain (solana or evm)
+            chain_id: Chain ID for EVM chains
         """
         self.app_id = app_id
         self.app_secret = app_secret
         self.client = client
+        self.chain_type = chain_type
+        self.chain_id = chain_id
         self.wallet_id = None
         self.wallet_address = None
 
@@ -41,14 +66,24 @@ class PrivyWalletClient(BaseWalletClient):
             "Content-Type": "application/json",
         }
 
-    def use_wallet(self, wallet_id: str) -> Dict[str, str]:
+    def _get_caip2(self):
+        """Get the CAIP-2 chain identifier based on chain type and ID."""
+        if self.chain_type == ChainType.SOLANA:
+            return (
+                "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"  # Solana mainnet
+            )
+        elif self.chain_type == ChainType.EVM:
+            return f"eip155:{self.chain_id}"  # EVM with chain ID
+        else:
+            raise ValueError(f"Unsupported chain type: {self.chain_type}")
 
-        payload = {"chain_type": "solana"}
+    def use_wallet(self, wallet_id: str) -> str:
+        """Use an existing wallet from Privy."""
+        payload = {"chain_type": self.chain_type}
         url = f"{self.BASE_URL}/v1/wallets/{wallet_id}"
 
         response = requests.get(url, headers=self._get_auth_headers(), json=payload)
         response_data = response.json()
-        print(response_data)
 
         if response.status_code != 200:
             raise Exception(f"Failed to use wallet: {response_data}")
@@ -59,6 +94,7 @@ class PrivyWalletClient(BaseWalletClient):
         return self.wallet_address
 
     def get_all_wallets(self) -> List[Dict[str, Any]]:
+        """Get all wallets associated with the Privy app."""
         url = f"{self.BASE_URL}/v1/wallets"
 
         response = requests.get(url, headers=self._get_auth_headers())
@@ -70,10 +106,13 @@ class PrivyWalletClient(BaseWalletClient):
         return response_data
 
     def create_wallet(self) -> Dict[str, str]:
-        """Create a new Solana wallet using Privy API."""
+        """Create a new wallet using Privy API."""
         url = f"{self.BASE_URL}/v1/wallets"
 
-        payload = {"chain_type": "solana"}
+        if self.chain_type == ChainType.SOLANA:
+            payload = {"chain_type": self.chain_type}
+        elif self.chain_type == ChainType.EVM:
+            payload = {"chain_type": "ethereum", "chain_id": self.chain_id}
 
         response = requests.post(url, headers=self._get_auth_headers(), json=payload)
         response_data = response.json()
@@ -84,27 +123,29 @@ class PrivyWalletClient(BaseWalletClient):
         self.wallet_id = response_data["id"]
         self.wallet_address = response_data["address"]
 
-        print("wallet_id", self.wallet_id)
-
         return {"id": self.wallet_id, "address": self.wallet_address}
 
     def get_address(self) -> str:
         """Get the wallet address."""
         if not self.wallet_address:
-            raise ValueError("Wallet not initialized. Call create_wallet first.")
+            raise ValueError(
+                "Wallet not initialized. Call create_wallet or use_wallet first."
+            )
         return self.wallet_address
 
     def sign_message(self, message: str) -> Dict[str, str]:
         """Sign a message with the wallet."""
         if not self.wallet_id:
-            raise ValueError("Wallet not initialized. Call create_wallet first.")
+            raise ValueError(
+                "Wallet not initialized. Call create_wallet or use_wallet first."
+            )
 
         url = f"{self.BASE_URL}/v1/wallets/{self.wallet_id}/rpc"
 
         payload = {
             "method": "signMessage",
-            "caip2": "solana:1",  # Solana mainnet
-            "chain_type": "solana",
+            "caip2": self._get_caip2(),
+            "chain_type": self.chain_type,
             "params": {"message": message},
         }
 
@@ -116,45 +157,104 @@ class PrivyWalletClient(BaseWalletClient):
 
         return {"signature": response_data["data"]["signature"]}
 
-    def balance_of(self, address: str) -> Dict:
-        pubkey = Pubkey.from_string(address)
-        balance_lamports = self.client.get_balance(pubkey).value
-        return {
-            "decimals": 9,
-            "symbol": "SOL",
-            "value": str(balance_lamports / 10**9),
-            "in_base_units": str(balance_lamports),
-        }
+    def balance_of(self, address: Optional[str] = None) -> Dict:
+        """Get the balance of the specified address."""
+        if not address:
+            address = self.wallet_address
 
-    async def send_transaction(self, transactionData):
-        """Send a Solana transaction using Privy API."""
+        if not address:
+            raise ValueError("No address provided and wallet not initialized.")
+
+        if self.chain_type == ChainType.SOLANA:
+            # Solana balance query
+            pubkey = Pubkey.from_string(address)
+            balance_lamports = self.client.get_balance(pubkey).value
+            return {
+                "decimals": 9,
+                "symbol": "SOL",
+                "value": str(balance_lamports / 10**9),
+                "in_base_units": str(balance_lamports),
+            }
+        elif self.chain_type == ChainType.EVM:
+            # EVM balance query
+            balance_wei = self.client.eth.get_balance(to_checksum_address(address))
+            return {
+                "decimals": 18,
+                "symbol": "ETH",  # This would ideally be dynamic based on the chain
+                "value": str(Web3.from_wei(balance_wei, "ether")),
+                "in_base_units": str(balance_wei),
+            }
+        else:
+            raise ValueError(f"Unsupported chain type: {self.chain_type}")
+
+    async def send_transaction(self, transaction_data: Any) -> Dict[str, str]:
+        """
+        Send a transaction using Privy API.
+
+        For Solana: transaction_data should be base64 encoded transaction
+        For EVM: transaction_data should be an EVMTransaction object
+        """
         if not self.wallet_id:
-            raise ValueError("Wallet not initialized. Call create_wallet first.")
-
-        BASE_URL = "https://auth.privy.io"
-        url = f"{BASE_URL}/v1/wallets/{self.wallet_id}/rpc"
-
-        payload = {
-            "method": "signAndSendTransaction",
-            "caip2": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",  # Solana mainnet
-            "params": {
-                "transaction": transactionData,
-                "encoding": "base64",
-            },
-        }
-
-        try:
-            print("Sending transaction to Privy API...")
-
-            response = requests.post(
-                url, headers=self._get_auth_headers(), json=payload
+            raise ValueError(
+                "Wallet not initialized. Call create_wallet or use_wallet first."
             )
 
-            print(f"Response status: {response.status_code}")
+        # Default URL (used for EVM eth_sendTransaction)
+        url = f"{self.BASE_URL}/v1/wallets/{self.wallet_id}/rpc"
+
+        if self.chain_type == ChainType.SOLANA:
+            # Use AUTH_URL for signAndSendTransaction for Solana
+            url = f"{self.AUTH_URL}/v1/wallets/{self.wallet_id}/rpc"
+            payload = {
+                "method": "signAndSendTransaction",
+                # Hardcoded Solana Mainnet CAIP-2
+                "caip2": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "params": {
+                    "transaction": transaction_data,  # Expects base64 encoded string
+                    "encoding": "base64",
+                },
+            }
+        elif self.chain_type == ChainType.EVM:
+            if not isinstance(transaction_data, EVMTransaction):
+                raise TypeError(
+                    "transaction_data must be an EVMTransaction for EVM chains"
+                )
+
+            # Construct the transaction object for eth_sendTransaction
+            evm_transaction_param = {
+                "to": transaction_data.to,
+                "value": hex(
+                    transaction_data.value
+                ),  # Value must be hex encoded string
+            }
+            # Include data if present (for contract interactions)
+            if transaction_data.data and transaction_data.data != "0x":
+                evm_transaction_param["data"] = transaction_data.data
+            # Include gas if provided
+            if transaction_data.gas:
+                evm_transaction_param["gas"] = hex(transaction_data.gas)
+
+            payload = {
+                "method": "eth_sendTransaction",
+                # Hardcoded EVM CAIP-2 (Base Mainnet)
+                "caip2": "eip155:8453",
+                "params": {
+                    "transaction": evm_transaction_param,
+                },
+            }
+        else:
+            raise ValueError(f"Unsupported chain type: {self.chain_type}")
+
+        # Use appropriate headers (auth headers are needed for both endpoints)
+        headers = self._get_auth_headers()
+        # Privy docs for eth_sendTransaction show using -u for basic auth AND privy-app-id header.
+        # The _get_auth_headers already includes both Authorization: Basic and privy-app-id.
+
+        try:
+            response = requests.post(url, headers=headers, json=payload)
 
             try:
                 response_data = response.json()
-                print(f"Response data: {json.dumps(response_data)}")
 
                 if response.status_code != 200:
                     raise Exception(
@@ -164,16 +264,13 @@ class PrivyWalletClient(BaseWalletClient):
                 return {"hash": response_data["data"]["hash"]}
 
             except json.JSONDecodeError:
-                print("Response is not valid JSON")
                 if response.status_code != 200:
                     raise Exception(f"Failed to send transaction: {response.text}")
 
         except requests.exceptions.RequestException as error:
-            print(f"Error response: {error}")
             if hasattr(error, "response") and error.response:
                 try:
                     error_data = error.response.json()
-                    print(f"Error response: {json.dumps(error_data)}")
                     raise Exception(
                         f"Failed to send transaction: {json.dumps(error_data)}"
                     )

--- a/agentipy/wallet/privy_wallet_client.py
+++ b/agentipy/wallet/privy_wallet_client.py
@@ -126,7 +126,7 @@ class PrivyWalletClient(BaseWalletClient):
             "in_base_units": str(balance_lamports),
         }
 
-    def send_transaction(self, transactionData) -> Dict[str, str]:
+    async def send_transaction(self, transactionData):
         """Send a Solana transaction using Privy API."""
         if not self.wallet_id:
             raise ValueError("Wallet not initialized. Call create_wallet first.")

--- a/agentipy/wallet/solana_wallet_client.py
+++ b/agentipy/wallet/solana_wallet_client.py
@@ -9,6 +9,8 @@ from solders.keypair import Keypair  # type: ignore
 from solders.pubkey import Pubkey  # type: ignore
 from solders.transaction import Transaction  # type: ignore
 
+from .base_wallet_client import BaseWalletClient
+
 
 class SolanaTransaction:
     """Transaction parameters for Solana."""
@@ -21,7 +23,7 @@ class SolanaTransaction:
         self.accounts_to_sign = accounts_to_sign
 
 
-class SolanaWalletClient:
+class SolanaWalletClient(BaseWalletClient):
     """Solana wallet implementation."""
 
     def __init__(self, client: SolanaClient, keypair: Keypair):

--- a/agentipy/wallet/solana_wallet_client.py
+++ b/agentipy/wallet/solana_wallet_client.py
@@ -7,17 +7,18 @@ from solana.rpc.types import TxOpts
 from solders.instruction import Instruction  # type: ignore
 from solders.keypair import Keypair  # type: ignore
 from solders.pubkey import Pubkey  # type: ignore
-from solders.transaction import Transaction  # type: ignore
+from solana.transaction import Transaction  # type: ignore
 
 from .base_wallet_client import BaseWalletClient
 
 
 class SolanaTransaction:
     """Transaction parameters for Solana."""
+
     def __init__(
-        self, 
-        instructions: List[Instruction], 
-        accounts_to_sign: Optional[List[Keypair]] = None
+        self,
+        instructions: List[Instruction],
+        accounts_to_sign: Optional[List[Keypair]] = None,
     ):
         self.instructions = instructions
         self.accounts_to_sign = accounts_to_sign
@@ -48,7 +49,7 @@ class SolanaWalletClient(BaseWalletClient):
             "in_base_units": str(balance_lamports),
         }
 
-    def send_transaction(self, transaction: SolanaTransaction) -> Dict[str, str]:
+    async def send_transaction(self, transaction: SolanaTransaction) -> Dict[str, str]:
         recent_blockhash = self.client.get_latest_blockhash().value.blockhash
         tx = Transaction()
         tx.recent_blockhash = recent_blockhash
@@ -62,10 +63,23 @@ class SolanaWalletClient(BaseWalletClient):
             signers.extend(transaction.accounts_to_sign)
 
         tx.sign(*signers)
-        result = self.client.send_transaction(
-            tx,
-            *signers,
-            opts=TxOpts(skip_preflight=False, max_retries=10, preflight_commitment=Confirmed),
-        )
-        self.client.confirm_transaction(result.value, commitment=Confirmed)
+        # Check if client has async methods
+        if hasattr(self.client, "send_transaction_async"):
+            result = await self.client.send_transaction_async(
+                tx,
+                opts=TxOpts(
+                    skip_preflight=False, max_retries=10, preflight_commitment=Confirmed
+                ),
+            )
+            await self.client.confirm_transaction_async(
+                result.value, commitment=Confirmed
+            )
+        else:
+            result = self.client.send_transaction(
+                tx.serialize(),
+                opts=TxOpts(
+                    skip_preflight=False, max_retries=10, preflight_commitment=Confirmed
+                ),
+            )
+            self.client.confirm_transaction(result.value, commitment=Confirmed)
         return {"hash": str(result.value)}

--- a/privy.example.py
+++ b/privy.example.py
@@ -1,0 +1,64 @@
+import asyncio
+import agentipy
+from agentipy import SolanaAgentKit
+from agentipy.tools.get_balance import BalanceFetcher
+from agentipy.tools.trade import TradeManager
+from agentipy.tools.transfer import TokenTransferManager
+from solders.pubkey import Pubkey  # type: ignore
+
+print(agentipy.__name__)
+
+""" agent = SolanaAgentKit(
+    private_key="",
+    rpc_url="https://api.mainnet-beta.solana.com",
+) """
+
+agent = SolanaAgentKit(
+    use_privy_wallet=True,
+    privy_app_secret="",
+    privy_app_id="",
+    generate_wallet=False,
+    privy_wallet_id="",
+)
+
+addressToTransfer = ""
+
+
+async def getBalance():
+    bal = await BalanceFetcher.get_balance(agent)
+    print("balance is: ", bal)
+
+
+async def transfer():
+    transfer = await TokenTransferManager.transfer(agent, addressToTransfer, 0.0001)
+    print("wallet", transfer)
+
+
+async def swap():
+    USDC_MINT = Pubkey.from_string("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+    SOL_MINT = Pubkey.from_string("So11111111111111111111111111111111111111112")
+
+    SWAP_AMOUNT_SOL = 0.0001
+    transaction_signature = await TradeManager.trade(
+        agent=agent,
+        output_mint=USDC_MINT,
+        input_amount=SWAP_AMOUNT_SOL,
+        input_mint=SOL_MINT,
+    )
+
+    print(transaction_signature)
+
+
+async def stake():
+    transaction_signature = await agent.stake(100)
+    print(transaction_signature)
+
+
+async def main():
+    await getBalance()
+    # await transfer()
+    # await swap()
+    # await stake()
+
+
+asyncio.run(main())

--- a/privy.example.py
+++ b/privy.example.py
@@ -30,7 +30,7 @@ async def getBalance():
 
 
 async def transfer():
-    transfer = await TokenTransferManager.transfer(agent, addressToTransfer, 0.0001)
+    transfer = await TokenTransferManager.transfer(agent, addressToTransfer, 0.003)
     print("wallet", transfer)
 
 
@@ -56,7 +56,7 @@ async def stake():
 
 async def main():
     await getBalance()
-    # await transfer()
+    await transfer()
     # await swap()
     # await stake()
 

--- a/privyEvm.example.py
+++ b/privyEvm.example.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from agentipy import EvmAgentKit
+import agentipy
+from agentipy import SolanaAgentKit
+from agentipy.agent.evm import WalletType
+from agentipy.tools.get_balance import BalanceFetcher
+from agentipy.tools.trade import TradeManager
+from agentipy.tools.transfer import TokenTransferManager
+
+
+from agentipy.utils.evm.general.networks import BaseRPC
+from agentipy.utils.evm.tokens.base import USDC_BASE, WETH_BASE  # type: ignore
+
+print(agentipy.__name__)
+
+agent = EvmAgentKit(
+    network=BaseRPC,
+    wallet_type=WalletType.PRIVY,
+    privy_app_secret="",
+    privy_app_id="",
+    privy_wallet_id="",
+)
+
+addressToTransfer = ""
+
+
+async def transfer():
+    transfer = await TokenTransferManager.transfer(agent, addressToTransfer, 0.0001)
+
+
+async def swap():
+    trade = await agent.trade_on_uniswap(
+        input_token_address=WETH_BASE.address,
+        output_token_address=USDC_BASE.address,
+        amount_in_raw="5000000000000",
+        input_token_decimals=WETH_BASE.decimals,
+        output_token_decimals=USDC_BASE.decimals,
+        slippage=0.5,
+    )
+
+
+async def main():
+    await transfer()
+    # await swap()
+
+
+asyncio.run(main())


### PR DESCRIPTION
Added a new PrivyWalletClient with support for 
- getBalance,
- transfer,
- deployToken,
- stake 
- trade

Existing tools that don't require a private key or wallet ID already work with Privy directly, so no extra changes were needed there.