### PR TITLE
Adding _run method to LuloLendAssetsTool

### DIFF
--- a/agentipy/langchain/lulo/lend.py
+++ b/agentipy/langchain/lulo/lend.py
@@ -86,4 +86,7 @@ class LuloLendAssetsTool(BaseTool):
                 "transaction_signature": None,
                 "message": f"Error lending assets using Lulo: {str(e)}"
             }
+
+    def _run(self):
+        raise NotImplementedError("This tool only supports async execution via _arun. Please use the async interface.")
         


### PR DESCRIPTION
Currently cannot use the create_solana_tools function in the langchain submodule bc it doesn't implement this abstract method